### PR TITLE
make cli runnable

### DIFF
--- a/zazu/cli.py
+++ b/zazu/cli.py
@@ -27,3 +27,6 @@ cli.add_command(zazu.build.build)
 cli.add_command(zazu.dev.commands.dev)
 cli.add_command(zazu.repo.commands.repo)
 cli.add_command(zazu.tool.commands.tool)
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
- [x] @aramnhammer 

This makes zazu runnable via `python -m zazu.cli`