### PR TITLE
Make styling hook automatic

### DIFF
--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -42,7 +42,7 @@ def test_astyle():
 def test_autopep8():
     styler = zazu.plugins.autopep8_styler.Autopep8Styler()
     ret = styler.style_string('def foo ():\n  pass')
-    print ret
+    assert ret == 'def foo():\n    pass\n'
     assert ['*.py'] == styler.default_extensions()
 
 

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -38,11 +38,11 @@ def test_astyle(git_repo):
         bad_file_name = 'temp.c'
         write_c_file_with_bad_style(bad_file_name)
         styler = zazu.plugins.astyle_styler.AstyleStyler()
-        ret = styler.run([bad_file_name], verbose=False, dry_run=True, working_dir=dir)
+        ret = styler.run([bad_file_name], dry_run=True, working_dir=dir)
         assert dict(ret)[bad_file_name]
-        ret = styler.run([bad_file_name], verbose=False, dry_run=False, working_dir=dir)
+        ret = styler.run([bad_file_name], dry_run=False, working_dir=dir)
         assert dict(ret)[bad_file_name]
-        ret = styler.run([bad_file_name], verbose=False, dry_run=True, working_dir=dir)
+        ret = styler.run([bad_file_name], dry_run=True, working_dir=dir)
         assert not any(dict(ret).values())
         assert styler.default_extensions()
 
@@ -53,11 +53,11 @@ def test_autopep8(git_repo):
         bad_file_name = 'temp.py'
         write_py_file_with_bad_style(bad_file_name)
         styler = zazu.plugins.autopep8_styler.Autopep8Styler()
-        ret = styler.run([bad_file_name], verbose=False, dry_run=True, working_dir=dir)
+        ret = styler.run([bad_file_name], dry_run=True, working_dir=dir)
         assert dict(ret)[bad_file_name]
-        ret = styler.run([bad_file_name], verbose=True, dry_run=False, working_dir=dir)
+        ret = styler.run([bad_file_name], dry_run=False, working_dir=dir)
         assert dict(ret)[bad_file_name]
-        ret = styler.run([bad_file_name], verbose=True, dry_run=True, working_dir=dir)
+        ret = styler.run([bad_file_name], dry_run=True, working_dir=dir)
         assert not any(dict(ret).values())
         assert ['*.py'] == styler.default_extensions()
 
@@ -70,11 +70,11 @@ def test_clang_format(git_repo):
         bad_file_name = 'temp.c'
         write_c_file_with_bad_style(bad_file_name)
         styler = zazu.plugins.clang_format_styler.ClangFormatStyler(['-style=google'])
-        ret = styler.run([bad_file_name], verbose=False, dry_run=True, working_dir=dir)
+        ret = styler.run([bad_file_name], dry_run=True, working_dir=dir)
         assert dict(ret)[bad_file_name]
-        ret = styler.run([bad_file_name], verbose=True, dry_run=False, working_dir=dir)
+        ret = styler.run([bad_file_name], dry_run=False, working_dir=dir)
         assert dict(ret)[bad_file_name]
-        ret = styler.run([bad_file_name], verbose=True, dry_run=True, working_dir=dir)
+        ret = styler.run([bad_file_name], dry_run=True, working_dir=dir)
         assert not dict(ret)[bad_file_name]
         assert styler.default_extensions()
 
@@ -122,4 +122,4 @@ def test_style_no_config(repo_with_missing_style):
 def test_styler():
     uut = zazu.styler.Styler()
     with pytest.raises(NotImplementedError):
-        uut.style_file('', False, False)
+        uut.style_string('')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -62,13 +62,13 @@ def test_check_popen(mocker):
     mocked_process.communicate = mocker.Mock(return_value=('out', 'err'))
     mocker.patch('subprocess.Popen', return_value=mocked_process)
     mocked_process.returncode = 0
-    assert 'out' == zazu.util.check_popen(stdinput_str='input', args=['foo'])
+    assert 'out' == zazu.util.check_popen(stdin_str='input', args=['foo'])
     subprocess.Popen.assert_called_once_with(args=['foo'], stderr=subprocess.PIPE,
                                              stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     mocked_process.communicate.assert_called_once_with('input')
     with pytest.raises(subprocess.CalledProcessError) as e:
         mocked_process.returncode = 1
-        zazu.util.check_popen(stdinput_str='input', args=['foo'])
+        zazu.util.check_popen(stdin_str='input', args=['foo'])
     assert e.value.returncode == 1
     assert e.value.cmd == ['foo']
     assert e.value.output == 'err'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@
 import click
 import os
 import pytest
+import subprocess
 import tempfile
 import zazu.util
 try:
@@ -38,15 +39,35 @@ def test_scan_tree():
 def test_check_output(mocker):
     mocker.patch('subprocess.check_output', side_effect=OSError(''))
     with pytest.raises(click.ClickException):
-        zazu.util.check_output('foo')
-        subprocess.check_output.assert_called_once_with('foo')
+        zazu.util.check_output(['foo'])
+        subprocess.check_output.assert_called_once_with(['foo'])
 
 
 def test_call(mocker):
     mocker.patch('subprocess.call', side_effect=OSError(''))
     with pytest.raises(click.ClickException):
-        zazu.util.call('foo')
-        subprocess.call.assert_called_once_with('foo')
+        zazu.util.call(['foo'])
+        subprocess.call.assert_called_once_with(['foo'])
+
+
+def test_check_popen_not_found(mocker):
+    mocker.patch('subprocess.Popen', side_effect=OSError(''))
+    with pytest.raises(click.ClickException):
+        zazu.util.check_popen(['foo'])
+        subprocess.call.assert_called_once_with(['foo'])
+
+
+def test_check_popen(mocker):
+    mocked_process = mocker.Mock()
+    mocked_process.returncode = 1
+    mocked_process.communicate = mocker.Mock(return_value=('out', 'err'))
+    mocker.patch('subprocess.Popen', return_value=mocked_process)
+    with pytest.raises(subprocess.CalledProcessError):
+        zazu.util.check_popen(stdinput_str='input', args=['foo'])
+        subprocess.Popen.assert_called_once_with(['foo'])
+        mocked_process.communicate.assert_called_once_with('input')
+    mocked_process.returncode = 0
+    assert 'out' = zazu.util.check_popen(stdinput_str='input', args=['foo'])
 
 
 def call(*args, **kwargs):

--- a/zazu/cli.py
+++ b/zazu/cli.py
@@ -23,6 +23,7 @@ def cli(ctx):
 
 
 def init():
+    """Run on startup to allow zazu to be run as a module."""
     if __name__ == "__main__":
         cli()
 

--- a/zazu/git_helper.py
+++ b/zazu/git_helper.py
@@ -107,5 +107,5 @@ def filter_undeletable(branches):
 
 
 def read_staged(path):
-    """Read the contents of the staged version of the file"""
+    """Read the contents of the staged version of the file."""
     return zazu.util.check_output(['git', 'show', ':{}'.format(path)])

--- a/zazu/git_helper.py
+++ b/zazu/git_helper.py
@@ -104,3 +104,8 @@ def filter_undeletable(branches):
     """Filter out branches that we don't want to delete."""
     undeletable = set(['master', 'develop', 'origin/develop', 'origin/master', '-', 'HEAD'])
     return [b for b in branches if (b not in undeletable) and (not b.startswith('*')) and (not b.startswith('origin/HEAD'))]
+
+
+def read_staged(path):
+    """Read the contents of the staged version of the file"""
+    return zazu.util.check_output(['git', 'show', ':{}'.format(path)])

--- a/zazu/githooks/pre-commit
+++ b/zazu/githooks/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-zazu style --check --dirty
+zazu style --cached

--- a/zazu/githooks/pre-commit
+++ b/zazu/githooks/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-zazu style --cached
+zazu style --cached -v

--- a/zazu/plugins/astyle_styler.py
+++ b/zazu/plugins/astyle_styler.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """astyle plugin for zazu."""
 import zazu.styler
-import zazu.util
+zazu.util.lazy_import(locals(), [
+    'subprocess'
+])
 
 __author__ = "Nicholas Wiles"
 __copyright__ = "Copyright 2017"
@@ -12,12 +14,23 @@ class AstyleStyler(zazu.styler.Styler):
 
     def style_file(self, path, verbose, dry_run):
         """Check a single file to see if it is within style guidelines and optionally fix it."""
-        args = ['astyle', '--formatted'] + self.options
-        if dry_run:
-            args.append('--dry-run')
-        args.append(path)
-        output = zazu.util.check_output(args)
-        return path, bool(output)
+        with open(path, 'r') as f:
+            input_string = f.read()
+            styled_string = self.style_string(input_string)
+        if not dry_run:
+            with open(path, 'w') as f:
+                f.write(styled_string)
+        changed = input_string != styled_string
+        return path, changed
+
+    def style_string(self, string):
+        """Fix a string to be within style guidelines."""
+        args = ['astyle'] + self.options
+        p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate(string)
+        if p.returncode:
+            raise subprocess.CalledProcessError(stderr)
+        return stdout
 
     @staticmethod
     def default_extensions():

--- a/zazu/plugins/astyle_styler.py
+++ b/zazu/plugins/astyle_styler.py
@@ -15,11 +15,7 @@ class AstyleStyler(zazu.styler.Styler):
     def style_string(self, string):
         """Fix a string to be within style guidelines."""
         args = ['astyle'] + self.options
-        p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = p.communicate(string)
-        if p.returncode:
-            raise subprocess.CalledProcessError(stderr)
-        return stdout
+        return zazu.util.check_popen(args=args, stdinput_str=string)
 
     @staticmethod
     def default_extensions():

--- a/zazu/plugins/astyle_styler.py
+++ b/zazu/plugins/astyle_styler.py
@@ -15,7 +15,7 @@ class AstyleStyler(zazu.styler.Styler):
     def style_string(self, string):
         """Fix a string to be within style guidelines."""
         args = ['astyle'] + self.options
-        return zazu.util.check_popen(args=args, stdinput_str=string)
+        return zazu.util.check_popen(args=args, stdin_str=string)
 
     @staticmethod
     def default_extensions():

--- a/zazu/plugins/astyle_styler.py
+++ b/zazu/plugins/astyle_styler.py
@@ -12,17 +12,6 @@ __copyright__ = "Copyright 2017"
 class AstyleStyler(zazu.styler.Styler):
     """Astyle plugin for code styling."""
 
-    def style_file(self, path, verbose, dry_run):
-        """Check a single file to see if it is within style guidelines and optionally fix it."""
-        with open(path, 'r') as f:
-            input_string = f.read()
-            styled_string = self.style_string(input_string)
-        if not dry_run:
-            with open(path, 'w') as f:
-                f.write(styled_string)
-        changed = input_string != styled_string
-        return path, changed
-
     def style_string(self, string):
         """Fix a string to be within style guidelines."""
         args = ['astyle'] + self.options

--- a/zazu/plugins/autopep8_styler.py
+++ b/zazu/plugins/autopep8_styler.py
@@ -16,7 +16,7 @@ class Autopep8Styler(zazu.styler.Styler):
     def style_string(self, string):
         """Fix a string to be within style guidelines."""
         args = ['autopep8'] + self.options + ['-']
-        return zazu.util.check_popen(args=args, stdinput_str=string)
+        return zazu.util.check_popen(args=args, stdin_str=string)
 
     @staticmethod
     def default_extensions():

--- a/zazu/plugins/autopep8_styler.py
+++ b/zazu/plugins/autopep8_styler.py
@@ -16,11 +16,7 @@ class Autopep8Styler(zazu.styler.Styler):
     def style_string(self, string):
         """Fix a string to be within style guidelines."""
         args = ['autopep8'] + self.options + ['-']
-        p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = p.communicate(string)
-        if p.returncode:
-            raise subprocess.CalledProcessError(stderr)
-        return stdout
+        return zazu.util.check_popen(args=args, stdinput_str=string)
 
     @staticmethod
     def default_extensions():

--- a/zazu/plugins/autopep8_styler.py
+++ b/zazu/plugins/autopep8_styler.py
@@ -13,17 +13,6 @@ __copyright__ = "Copyright 2016"
 class Autopep8Styler(zazu.styler.Styler):
     """Autopep8 plugin for code styling."""
 
-    def style_file(self, path, verbose, dry_run):
-        """Check a single file to see if it is within style guidelines and optionally fix it."""
-        with open(path, 'r') as f:
-            input_string = f.read()
-            styled_string = self.style_string(input_string)
-        if not dry_run:
-            with open(path, 'w') as f:
-                f.write(styled_string)
-        changed = input_string != styled_string
-        return path, changed
-
     def style_string(self, string):
         """Fix a string to be within style guidelines."""
         args = ['autopep8'] + self.options + ['-']

--- a/zazu/plugins/clang_format_styler.py
+++ b/zazu/plugins/clang_format_styler.py
@@ -16,11 +16,7 @@ class ClangFormatStyler(zazu.styler.Styler):
     def style_string(self, string):
         """Fix a string to be within style guidelines."""
         args = ['clang-format'] + self.options
-        p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = p.communicate(string)
-        if p.returncode:
-            raise subprocess.CalledProcessError(stderr)
-        return stdout
+        return zazu.util.check_popen(args=args, stdinput_str=string)
 
     @staticmethod
     def default_extensions():

--- a/zazu/plugins/clang_format_styler.py
+++ b/zazu/plugins/clang_format_styler.py
@@ -16,7 +16,7 @@ class ClangFormatStyler(zazu.styler.Styler):
     def style_string(self, string):
         """Fix a string to be within style guidelines."""
         args = ['clang-format'] + self.options
-        return zazu.util.check_popen(args=args, stdinput_str=string)
+        return zazu.util.check_popen(args=args, stdin_str=string)
 
     @staticmethod
     def default_extensions():

--- a/zazu/plugins/clang_format_styler.py
+++ b/zazu/plugins/clang_format_styler.py
@@ -13,17 +13,6 @@ __copyright__ = "Copyright 2017"
 class ClangFormatStyler(zazu.styler.Styler):
     """ClangFormat plugin for code styling."""
 
-    def style_file(self, path, verbose, dry_run):
-        """Check a single file to see if it is within style guidelines and optionally fix it."""
-        with open(path, 'r') as f:
-            input_string = f.read()
-            styled_string = self.style_string(input_string)
-        if not dry_run:
-            with open(path, 'w') as f:
-                f.write(styled_string)
-        changed = input_string != styled_string
-        return path, changed
-
     def style_string(self, string):
         """Fix a string to be within style guidelines."""
         args = ['clang-format'] + self.options

--- a/zazu/style.py
+++ b/zazu/style.py
@@ -8,9 +8,7 @@ zazu.util.lazy_import(locals(), [
     'difflib',
     'functools',
     'os',
-    'subprocess',
-    'tempfile'
-
+    'subprocess'
 ])
 
 __author__ = "Nicholas Wiles"
@@ -22,44 +20,14 @@ default_exclude_paths = ['build',
                          'dependencies']
 
 
-class threadsafe_iter:
-    """Takes an iterator/generator and makes it thread-safe by
-    serializing call to the `next` method of given iterator/generator.
-    """
-
-    def __init__(self, it):
-        self.it = it
-        self.lock = threading.Lock()
-
-    def __iter__(self):
-        return self
-
-    def next(self):
-        with self.lock:
-            return self.it.next()
-
-
-def threadsafe_generator(f):
-    """A decorator that takes a generator function and makes it thread-safe.
-    """
-    def g(*a, **kw):
-        return threadsafe_iter(f(*a, **kw))
-    return g
-
-
-@threadsafe_generator
-def file_contents_generator(files):
-    for f in files:
-        with open(f, 'r') as f:
-            yield f.read()
-
-
 def read_file(path):
+    """Read a file and return its contents as a string."""
     with open(path, 'r') as f:
         return f.read()
 
 
 def write_file(path, _, styled_string):
+    """Write styled_string string to a file."""
     with open(path, 'w') as f:
         return f.write(styled_string)
 

--- a/zazu/style.py
+++ b/zazu/style.py
@@ -90,6 +90,8 @@ def style(ctx, verbose, check, cached):
     file_count = 0
     violation_count = 0
     stylers = ctx.obj.stylers()
+    FIXED_OK = [click.style('FIXED', fg='red', bold=True), click.style(' OK  ', fg='green', bold=True)]
+    tags = zazu.util.FAIL_OK if check else FIXED_OK
     with zazu.util.cd(ctx.obj.repo_root):
         if stylers:
             if cached:
@@ -113,7 +115,7 @@ def style(ctx, verbose, check, cached):
                 checked_files = zazu.util.dispatch([functools.partial(style_file, s, f, read_fn, write_fn) for f in files])
                 for f, violation in checked_files:
                     if verbose:
-                        click.echo(zazu.util.format_checklist_item(not violation, text='({}) {}'.format(s.type(), f)))
+                        click.echo(zazu.util.format_checklist_item(not violation, text='({}) {}'.format(s.type(), f), tag_formats=tags))
                     violation_count += violation
             if verbose:
                 if check:

--- a/zazu/style.py
+++ b/zazu/style.py
@@ -112,7 +112,8 @@ def style(ctx, verbose, check, cached):
                 if check:
                     write_fn = None
                 file_count += len(files)
-                checked_files = zazu.util.dispatch([functools.partial(style_file, s, f, read_fn, write_fn) for f in files])
+                work = [functools.partial(style_file, s, f, read_fn, write_fn) for f in files]
+                checked_files = zazu.util.dispatch(work)
                 for f, violation in checked_files:
                     if verbose:
                         click.echo(zazu.util.format_checklist_item(not violation, text='({}) {}'.format(s.type(), f), tag_formats=tags))

--- a/zazu/style.py
+++ b/zazu/style.py
@@ -4,7 +4,13 @@ import zazu.git_helper
 import zazu.styler
 import zazu.util
 zazu.util.lazy_import(locals(), [
-    'click'
+    'click',
+    'difflib',
+    'functools',
+    'os',
+    'subprocess',
+    'tempfile'
+
 ])
 
 __author__ = "Nicholas Wiles"
@@ -16,19 +22,79 @@ default_exclude_paths = ['build',
                          'dependencies']
 
 
+class threadsafe_iter:
+    """Takes an iterator/generator and makes it thread-safe by
+    serializing call to the `next` method of given iterator/generator.
+    """
+
+    def __init__(self, it):
+        self.it = it
+        self.lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        with self.lock:
+            return self.it.next()
+
+
+def threadsafe_generator(f):
+    """A decorator that takes a generator function and makes it thread-safe.
+    """
+    def g(*a, **kw):
+        return threadsafe_iter(f(*a, **kw))
+    return g
+
+
+@threadsafe_generator
+def file_contents_generator(files):
+    for f in files:
+        with open(f, 'r') as f:
+            yield f.read()
+
+
+def read_file(path):
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def write_file(path, _, styled_string):
+    with open(path, 'w') as f:
+        return f.write(styled_string)
+
+
+def stage_patch(path, input_string, styled_string):
+    """Create a patch between input_string and output_string and add the patch to the git staging area.
+
+    Args:
+        path: the path of the file being patched.
+        input_string: the current state of the file in the git stage.
+        styled_string: the properly styled string to stage.
+    """
+    input_lines = input_string.splitlines()
+    styled_lines = styled_string.splitlines()
+    patch = difflib.unified_diff(input_lines, styled_lines, 'a/' + path, 'b/' + path, lineterm='')
+    patch_string = '\n'.join(patch) + '\n'
+    p = subprocess.Popen(['git', 'apply', '--cached', '-'], stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    _, stderr = p.communicate(patch_string)
+    if p.returncode:
+        raise CalledProcessError(str(stderr))
+
+
 @click.command()
 @click.pass_context
 @click.option('-v', '--verbose', is_flag=True, help='print files that are dirty')
 @click.option('--check', is_flag=True, help='only check the repo for style violations, do not correct them')
-@click.option('--dirty', is_flag=True, help='only examine files that are staged for CI commit')
-def style(ctx, verbose, check, dirty):
+@click.option('--cached', is_flag=True, help='only examine/fix files that are staged for CI commit')
+def style(ctx, verbose, check, cached):
     """Style repo files or check that they are valid style."""
     ctx.obj.check_repo()
     file_count = 0
     violation_count = 0
     stylers = ctx.obj.stylers()
     if stylers:
-        if dirty:
+        if cached:
             dirty_files = zazu.git_helper.get_touched_files(ctx.obj.repo)
         # Run each Styler
         for s in stylers:
@@ -36,14 +102,22 @@ def style(ctx, verbose, check, dirty):
                                        s.includes,
                                        s.excludes,
                                        exclude_hidden=True)
-            if dirty:
+            if cached:
                 files = set(files).intersection(dirty_files)
+                read_fn = zazu.git_helper.read_staged
+                write_fn = stage_patch
+            else:
+                read_fn = read_file
+                write_fn = write_file
+            if check:
+                write_fn = None
             file_count += len(files)
-            checked_files = s.run(files, verbose, check, ctx.obj.repo_root)
-            for f, violation in checked_files:
-                if verbose:
-                    click.echo(zazu.util.format_checklist_item(not violation, text='({}) {}'.format(s.type(), f)))
-                violation_count += violation
+            with zazu.util.cd(ctx.obj.repo_root):
+                checked_files = zazu.util.dispatch([functools.partial(s.style_one, f, read_fn, write_fn) for f in files])
+                for f, violation in checked_files:
+                    if verbose:
+                        click.echo(zazu.util.format_checklist_item(not violation, text='({}) {}'.format(s.type(), f)))
+                    violation_count += violation
         if verbose:
             if check:
                 click.echo('{} files with violations in {} files'.format(violation_count, file_count))

--- a/zazu/style.py
+++ b/zazu/style.py
@@ -116,7 +116,9 @@ def style(ctx, verbose, check, cached):
                 checked_files = zazu.util.dispatch(work)
                 for f, violation in checked_files:
                     if verbose:
-                        click.echo(zazu.util.format_checklist_item(not violation, text='({}) {}'.format(s.type(), f), tag_formats=tags))
+                        click.echo(zazu.util.format_checklist_item(not violation,
+                                                                   text='({}) {}'.format(s.type(), f),
+                                                                   tag_formats=tags))
                     violation_count += violation
             if verbose:
                 if check:

--- a/zazu/style.py
+++ b/zazu/style.py
@@ -7,8 +7,7 @@ zazu.util.lazy_import(locals(), [
     'click',
     'difflib',
     'functools',
-    'os',
-    'subprocess'
+    'os'
 ])
 
 __author__ = "Nicholas Wiles"
@@ -54,12 +53,7 @@ def stage_patch(path, input_string, styled_string):
             # This is to address a bizarre issue with git apply whereby if the staged file doesn't end in a newline,
             # the patch will fail to apply.
             raise click.ClickException('File "{}" must have a trailing newline'.format(path))
-        p = subprocess.Popen(['git', 'apply', '--cached', '--verbose', '-'],
-                             stdin=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
-        _, stderr = p.communicate(patch_string)
-        if p.returncode:
-            raise click.ClickException(str(stderr))
+        zazu.util.check_popen(args=['git', 'apply', '--cached', '--verbose', '-'], stdin_str=patch_string)
 
 
 def style_file(styler, path, read_fn, write_fn):

--- a/zazu/styler.py
+++ b/zazu/styler.py
@@ -33,22 +33,6 @@ class Styler(object):
             write_fn(path, input_string, styled_string)
         return path, violation
 
-    def style_file(self, path, dry_run):
-        """Style a single file.
-
-        Args:
-            path: absolute path to the file to style.
-            dry_run: if true, doesn't touch local files.
-        """
-        with open(path, 'r') as f:
-            input_string = f.read()
-            styled_string = self.style_string(input_string)
-        if not dry_run:
-            with open(path, 'w') as f:
-                f.write(styled_string)
-        changed = input_string != styled_string
-        return path, changed
-
     def style_string(self, string):
         """Style a string and return a diff of requested changes
 

--- a/zazu/styler.py
+++ b/zazu/styler.py
@@ -53,6 +53,20 @@ class Styler(object):
         """
         raise NotImplementedError('All style plugins must implement style_file()')
 
+    def style_string(self, string):
+        """Style a string and return a diff of requested changes
+
+        Args:
+            string: the string to style
+
+        Returns:
+                A unified diff of requested changes or an empty string if no changes are requested.
+
+        Raises:
+            NotImplementedError
+        """
+        raise NotImplementedError('All style plugins must implement style_string')
+
     @classmethod
     def from_config(cls, config, excludes, includes):
         """Create a Styler based on a configuration dictionary.

--- a/zazu/styler.py
+++ b/zazu/styler.py
@@ -25,16 +25,8 @@ class Styler(object):
         self.excludes = excludes
         self.includes = includes
 
-    def style_one(self, path, read_fn, write_fn):
-        input_string = read_fn(path)
-        styled_string = self.style_string(input_string)
-        violation = styled_string != input_string
-        if violation and callable(write_fn):
-            write_fn(path, input_string, styled_string)
-        return path, violation
-
     def style_string(self, string):
-        """Style a string and return a diff of requested changes
+        """Style a string and return a diff of requested changes.
 
         Args:
             string: the string to style
@@ -44,6 +36,7 @@ class Styler(object):
 
         Raises:
             NotImplementedError
+
         """
         raise NotImplementedError('All style plugins must implement style_string')
 

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -64,7 +64,7 @@ def call(*args, **kwargs):
         raise_uninstalled(args[0][0])
 
 
-def check_popen(args, stdinput_str='', *other_args, **kwargs):
+def check_popen(args, stdin_str='', *other_args, **kwargs):
     """Like subprocess.Popen but raises an exception if the program cannot be found.
 
     Args:
@@ -80,7 +80,7 @@ def check_popen(args, stdinput_str='', *other_args, **kwargs):
         p = subprocess.Popen(args=args, stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                              *other_args, **kwargs)
-        stdout, stderr = p.communicate(stdinput_str)
+        stdout, stderr = p.communicate(stdin_str)
     except OSError:
         raise_uninstalled(args[0][0])
     if p.returncode:

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -49,7 +49,7 @@ __copyright__ = "Copyright 2016"
 
 
 def check_output(*args, **kwargs):
-    """Like subprocess.check_output but raises an exception if it cannot be found."""
+    """Like subprocess.check_output but raises an exception if the program cannot be found."""
     try:
         return subprocess.check_output(*args, **kwargs)
     except OSError:
@@ -57,11 +57,35 @@ def check_output(*args, **kwargs):
 
 
 def call(*args, **kwargs):
-    """Like subprocess.call but raise an exception if it cannot be found."""
+    """Like subprocess.call but raise an exception if the program cannot be found."""
     try:
         return subprocess.call(*args, **kwargs)
     except OSError:
         raise_uninstalled(args[0][0])
+
+
+def check_popen(args, stdinput_str='', *other_args, **kwargs):
+    """Like subprocess.Popen but raises an exception if the program cannot be found.
+
+    Args:
+        args: passed to Popen.
+        stdinput_str: a string that will be sent to std input via communicate().
+        other_args: other arguments passed to Popen.
+        kwargs: other kwargs passed to Popen.
+    Raises:
+        CalledProcessError: on non zero return from the child process.
+        click.ClickException: if the program can't be found.
+    """
+    try:
+        p = subprocess.Popen(args=args, stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             *other_args, **kwargs)
+        stdout, stderr = p.communicate(stdinput_str)
+    except OSError:
+        raise_uninstalled(args[0][0])
+    if p.returncode:
+        raise subprocess.CalledProcessError(p.returncode, args, stderr)
+    return stdout
 
 
 @contextlib.contextmanager

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -75,6 +75,7 @@ def check_popen(args, stdin_str='', *other_args, **kwargs):
     Raises:
         CalledProcessError: on non zero return from the child process.
         click.ClickException: if the program can't be found.
+
     """
     try:
         p = subprocess.Popen(args=args, stdin=subprocess.PIPE,


### PR DESCRIPTION
This simplifies ths styler plugin API and makes the pre-commit hook style by default. No more refused commits. Styling will also inteligently patch only your staging area if you style using the new --cached flag while having a file partially staged.

Fixes #75