### PR TITLE
Add config subcommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ language: python
 python:
   - "2.7"
 
-# We must install astyle because 14.04's apt version is too old (doesn't support --dry-run)
-before_install:
-  - curl -L "https://sourceforge.net/projects/astyle/files/astyle/astyle%203.0/astyle_3.0_linux.tar.gz/download" | tar xvz
-  - pushd astyle/build/gcc && make -j$(getconf _NPROCESSORS_ONLN) all && sudo make install && popd
-
 # command to install dependencies
 install: pip install tox-travis
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,16 @@ language: python
 python:
   - "2.7"
 
+# We must install astyle because 14.04's apt version is too old (doesn't support --dry-run)
+before_install:
+  - curl -L "https://sourceforge.net/projects/astyle/files/astyle/astyle%203.0/astyle_3.0_linux.tar.gz/download" | tar xvz
+  - pushd astyle/build/gcc && make -j$(getconf _NPROCESSORS_ONLN) all && sudo make install && popd
+
 # command to install dependencies
-install: pip install tox-travis
+install:
+  - pip install tox-travis
+  - sudo apt-get install -y astyle
+
 # command to run tests
 script:
   tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ language: python
 python:
   - "2.7"
 
-# We must install astyle because 14.04's apt version is too old (doesn't support --dry-run)
-before_install:
-  - curl -L "https://sourceforge.net/projects/astyle/files/astyle/astyle%203.0/astyle_3.0_linux.tar.gz/download" | tar xvz
-  - pushd astyle/build/gcc && make -j$(getconf _NPROCESSORS_ONLN) all && sudo make install && popd
-
 # command to install dependencies
 install:
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
 # command to install dependencies
 install:
   - pip install tox-travis
-  - sudo apt-get install -y astyle
 
 # command to run tests
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,14 @@
 Changelog
 =========
 
-Version 0.10.1 (bugfixes, not yet released)
+Version 0.11 (Not yet released)
 -------------------------------------------
 
 - Update dependencies (old GitPython was broken).
 - Fix up documentation.
 - JIRA issue fetching normalizes ticket IDs to be uppercase. See #84.
+- Support ``zazu config`` subcommand to edit ~/.zazuconfig.yaml file. See #100.
+- Enable SCM hosting shortcuts for ``zazu repo clone``.
 
 Version 0.10.0 (Released Jul 2, 2017)
 -------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,17 @@ Zazu is fastest when installed in wheel form.
     python setup.py bdist_wheel
     pip install dist/*.whl
 
+Configuration
+-------------
+Setup your user config file (located in ~/zazuconfig.yaml).
+
+GitHub setup
+~~~~~~~~~~~~
+::
+
+    zazu config --add scmHost.default.type github
+    zazu config --add scmHost.default.user <github username>
+
 Command overview
 ----------------
 The following diagram shows the available subcommands of zazu.
@@ -98,9 +109,9 @@ The following diagram shows the available subcommands of zazu.
       "dev" -> "start"
       "dev" -> "status"
       dev_builds [label=builds, style=dashed]
+      "dev" -> "ticket"
       "dev" -> "dev_builds"
-      "dev" -> "review"
-      "dev" -> "ticket"}
+      "dev" -> "review"}
 
 Note: dashed lines are not yet implemented
 
@@ -160,7 +171,7 @@ You may pass extra variables to the build using key=value pairs.
 the environement variable *FOO* to the value *bar* during the build.
 
 ~/.zazuconfig.yaml file (user level configuration)
----------------------------------------------
+--------------------------------------------------
 
 The .zazuconfig.yaml is a file that lives in your home directory and sets high
 level configuration options for zazu. Most people will likely have a single
@@ -175,7 +186,7 @@ default scmHost entry, though zazu supports multiple named entries.
     default:              # This is the default SCM host.
       type: github        # Type of this SCM host.
       user: stopthatcow   # GitHub username
-    pat:                  # Another SCM host.
+    pat:                  # Optionally: another SCM host named "pat".
       type: github        # Type of this SCM host.
       user: moorepatrick  # GitHub username
 

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,7 @@ Command overview
 The following diagram shows the available subcommands of zazu.
 
 .. image:: https://g.gravizo.com/svg?digraph%20G%20{
+      "zazu" -> "config"
       "zazu" -> "build"
       "zazu" -> "style"
       "zazu" -> "repo"
@@ -158,12 +159,36 @@ You may pass extra variables to the build using key=value pairs.
 ``zazu build --arch=arm32-linux-gnueabihf package FOO=bar`` This sets
 the environement variable *FOO* to the value *bar* during the build.
 
-zazu.yaml file
---------------
+~/.zazuconfig.yaml file (user level configuration)
+---------------------------------------------
+
+The .zazuconfig.yaml is a file that lives in your home directory and sets high
+level configuration options for zazu. Most people will likely have a single
+default scmHost entry, though zazu supports multiple named entries.
+
+::
+
+  # User configuration file for zazu.
+
+  # SCM hosts are cloud hosting services for repos. Currently GitHub is supported.
+  scmHost:
+    default:              # This is the default SCM host.
+      type: github        # Type of this SCM host.
+      user: stopthatcow   # GitHub username
+    pat:                  # Another SCM host.
+      type: github        # Type of this SCM host.
+      user: moorepatrick  # GitHub username
+
+With the above configuration in place the following are allowed:
+
+- ``zazu repo clone stopthatcow/zazu`` Using the default host so we don't need the fully-qualified name.
+- ``zazu repo clone pat/moorepatrick/zazu`` This uses a non-default host so we need the name.
+
+zazu.yaml file (repo level configuration)
+-----------------------------------------
 
 The zazu.yaml file lives at the base of the repo and describes the CI
-goals and architectures to be run. In addition it describes the
-requirements for each goal.
+goals and architectures to be run.
 
 ::
 
@@ -269,4 +294,3 @@ Handy aliases
     alias zdb="zazu dev builds"
     alias zs="zazu style"
     alias zb="zazu build"
-

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
                       'PyGithub>=1.36.0',              # LGPL 3
                       'jira>=1.0.11',                  # BSD
                       'GitPython>=2.1.8',              # BSD
-                      'dict-recursive-update>=1.1.0',  # MIT
+                      'dict-recursive-update>=1.0.1',  # MIT
                       'pyteamcity>=0.1.1',             # MIT
                       'ruamel.yaml<=0.15',             # MIT
                       'keyring>=11.0',                 # MIT

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
                       'jira>=1.0.11',             # BSD
                       'GitPython>=2.1.8',         # BSD
                       'pyteamcity>=0.1.1',        # MIT
-                      'pyyaml>=3.12',             # MIT
+                      'ruamel.yaml<=0.15',        # MIT
                       'keyring>=11.0',            # MIT
                       'keyrings.alt>=2.3',        # MIT
                       'autopep8>=1.3.4',          # MIT

--- a/setup.py
+++ b/setup.py
@@ -50,27 +50,28 @@ setuptools.setup(
     keywords='teamcity, jira, git, github',
     packages=setuptools.find_packages(exclude=('tests', 'docs')),
     package_data={'zazu': ['githooks/*', 'version.txt']},
-    install_requires=['click>=6.7',               # BSD
-                      'requests>=2.18.4',         # Apache 2.0
-                      'PyGithub>=1.36.0',         # LGPL 3
-                      'jira>=1.0.11',             # BSD
-                      'GitPython>=2.1.8',         # BSD
-                      'pyteamcity>=0.1.1',        # MIT
-                      'ruamel.yaml<=0.15',        # MIT
-                      'keyring>=11.0',            # MIT
-                      'keyrings.alt>=2.3',        # MIT
-                      'autopep8>=1.3.4',          # MIT
-                      'semantic_version>=2.6.0',  # BSD
-                      'gcovr>=3.4',               # BSD
-                      'teamcity-messages>=1.21',  # Apache 2.0
-                      'future>=0.16.0',           # MIT
-                      'futures>=3.2.0',           # PSF
-                      'inquirer>=2.2.0',          # MIT
-                      'Importing>=1.10',          # PSF
-                      'straight.plugin>=1.5.0'],  # MIT
+    install_requires=['click>=6.7',                    # BSD
+                      'requests>=2.18.4',              # Apache 2.0
+                      'PyGithub>=1.36.0',              # LGPL 3
+                      'jira>=1.0.11',                  # BSD
+                      'GitPython>=2.1.8',              # BSD
+                      'dict-recursive-update>=1.1.0',  # MIT
+                      'pyteamcity>=0.1.1',             # MIT
+                      'ruamel.yaml<=0.15',             # MIT
+                      'keyring>=11.0',                 # MIT
+                      'keyrings.alt>=2.3',             # MIT
+                      'autopep8>=1.3.4',               # MIT
+                      'semantic_version>=2.6.0',       # BSD
+                      'gcovr>=3.4',                    # BSD
+                      'teamcity-messages>=1.21',       # Apache 2.0
+                      'future>=0.16.0',                # MIT
+                      'futures>=3.2.0',                # PSF
+                      'inquirer>=2.2.0',               # MIT
+                      'Importing>=1.10',               # PSF
+                      'straight.plugin>=1.5.0'],       # MIT
     extras_require={
         ':sys_platform == "win32"': [
-            'pyreadline>=2.1'                     # BSD
+            'pyreadline>=2.1'                          # BSD
         ]
     },
     entry_points='''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import git
 import tempfile
 import os
 import pytest
-import yaml
+import ruamel.yaml as yaml
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ def repo_with_style(git_repo):
         }
     }
     with open(os.path.join(root, 'zazu.yaml'), 'a') as file:
-        file.write(yaml.dump(style_config))
+        yaml.dump(style_config, file)
     return git_repo
 
 
@@ -87,7 +87,7 @@ def repo_with_build_config(git_repo):
         ]
     }
     with open(os.path.join(root, 'zazu.yaml'), 'a') as file:
-        file.write(yaml.dump(config))
+        yaml.dump(config, file)
     return git_repo
 
 
@@ -106,7 +106,7 @@ def repo_with_missing_style(git_repo):
         'components': [{'name': 'zazu'}]
     }
     with open(os.path.join(root, 'zazu.yaml'), 'a') as file:
-        file.write(yaml.dump(config))
+        yaml.dump(config, file)
     return git_repo
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -103,6 +103,27 @@ def test_unknown_styler():
         uut.stylers()
 
 
+def test_unknown_scm_host():
+    uut = zazu.config.Config('')
+    uut._user_config = {'scmHost': {'gh': {'type': ''}}}
+    with pytest.raises(click.ClickException):
+        uut.scm_hosts()
+
+
+def test_no_type_scm_host():
+    uut = zazu.config.Config('')
+    uut._user_config = {'scmHost': {'gh': {}}}
+    with pytest.raises(click.ClickException):
+        uut.scm_hosts()
+
+
+def test_github_scm_host():
+    uut = zazu.config.Config('')
+    uut._user_config = {'scmHost': {'gh': {'type': 'github', 'user': 'user'}}}
+    assert uut.scm_hosts()
+    assert uut.scm_hosts()['gh']
+
+
 def test_no_issue_tracker():
     uut = zazu.config.Config('')
     uut._project_config = {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@
 import click
 import os
 import pytest
-import yaml
+import ruamel.yaml as yaml
 import zazu.config
 
 __author__ = "Nicholas Wiles"
@@ -19,7 +19,7 @@ def repo_with_teamcity(git_repo):
         }
     }
     with open(os.path.join(root, 'zazu.yaml'), 'a') as file:
-        file.write(yaml.dump(teamcity_config))
+        yaml.dump(teamcity_config, file)
     return git_repo
 
 
@@ -32,7 +32,7 @@ def repo_with_invalid_ci(git_repo):
         }
     }
     with open(os.path.join(root, 'zazu.yaml'), 'a') as file:
-        file.write(yaml.dump(teamcity_config))
+        yaml.dump(teamcity_config, file)
     return git_repo
 
 
@@ -48,7 +48,7 @@ def repo_with_jira(git_repo):
         }
     }
     with open(os.path.join(root, 'zazu.yaml'), 'a') as file:
-        file.write(yaml.dump(jira_config))
+        yaml.dump(jira_config, file)
     return git_repo
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,14 @@ def temp_user_config(tmp_dir):
 
 
 @pytest.fixture()
+def empty_user_config(tmp_dir):
+    path = os.path.join(tmp_dir, '.zazuconfig.yaml')
+    with open(path, 'w'):
+        pass
+    return path
+
+
+@pytest.fixture()
 def repo_with_invalid_ci(git_repo):
     root = git_repo.working_tree_dir
     teamcity_config = {
@@ -176,6 +184,13 @@ def test_github_user_config(mocker, temp_user_config):
     assert uut.scm_hosts()
     print uut.scm_hosts()
     assert uut.scm_hosts()['gh']
+
+
+def test_empty_user_config(mocker, empty_user_config):
+    mocker.patch('zazu.config.user_config_filepath', return_value=empty_user_config)
+    uut = zazu.config.Config('')
+    with pytest.raises(click.ClickException) as e:
+        uut.scm_hosts()
 
 
 def test_no_issue_tracker():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,6 +141,33 @@ def test_github_scm_host():
     uut._user_config = {'scmHost': {'gh': {'type': 'github', 'user': 'user'}}}
     assert uut.scm_hosts()
     assert uut.scm_hosts()['gh']
+    assert uut.default_scm_host() == 'gh'
+
+
+def test_default_string_scm_host():
+    uut = zazu.config.Config('')
+    uut._user_config = {'scmHost': {'default': 'gh2',
+                                    'gh': {'type': 'github', 'user': 'user'},
+                                    'gh2': {'type': 'github', 'user': 'user'}}}
+    assert len(uut.scm_hosts()) == 2
+    assert uut.default_scm_host() == 'gh2'
+
+
+def test_default_dict_scm_host():
+    uut = zazu.config.Config('')
+    uut._user_config = {'scmHost': {'default': {'type': 'github', 'user': 'user'},
+                                    'gh': {'type': 'github', 'user': 'user'}}}
+    assert len(uut.scm_hosts()) == 2
+    assert uut.default_scm_host() == 'default'
+
+
+def test_bad_default_scm_host():
+    uut = zazu.config.Config('')
+    uut._user_config = {'scmHost': {'default': 'foo',
+                                    'gh': {'type': 'github', 'user': 'user'}}}
+    with pytest.raises(click.ClickException) as e:
+        assert uut.default_scm_host()
+        assert str(e.value) == 'default scmHost \'foo\' not found'
 
 
 def test_github_user_config(mocker, temp_user_config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -117,6 +117,13 @@ def test_no_type_scm_host():
         uut.scm_hosts()
 
 
+def test_no_scm_host():
+    uut = zazu.config.Config('')
+    uut._user_config = {}
+    with pytest.raises(click.ClickException):
+        uut.scm_hosts()
+
+
 def test_github_scm_host():
     uut = zazu.config.Config('')
     uut._user_config = {'scmHost': {'gh': {'type': 'github', 'user': 'user'}}}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,7 @@ def repo_with_teamcity(git_repo):
 @pytest.fixture()
 def temp_user_config(tmp_dir):
     config = {'scmHost': {'gh': {'type': 'github', 'user': 'user'}}}
-    path = os.path.join(tmp_dir, '.zazuconfig')
+    path = os.path.join(tmp_dir, '.zazuconfig.yaml')
     with open(path, 'w') as file:
         yaml.dump(config, file)
     return path
@@ -199,7 +199,7 @@ def test_valid_code_reviewer():
 
 
 def test_user_config_filepath():
-    assert zazu.config.user_config_filepath() == os.path.join(os.path.expanduser("~"), '.zazuconfig')
+    assert zazu.config.user_config_filepath() == os.path.join(os.path.expanduser("~"), '.zazuconfig.yaml')
 
 
 def test_config_bad_options(mocker, temp_user_config):
@@ -249,7 +249,7 @@ def test_config_add_unset(mocker, temp_user_config):
 
 
 def test_config_create(mocker, tmp_dir):
-    path = os.path.join(tmp_dir, '.zazuconfig')
+    path = os.path.join(tmp_dir, '.zazuconfig.yaml')
     mocker.patch('zazu.config.user_config_filepath', return_value=path)
     assert not os.path.isfile(path)
     runner = click.testing.CliRunner()

--- a/tests/test_github_scm_host.py
+++ b/tests/test_github_scm_host.py
@@ -24,47 +24,6 @@ mock_repo_dict = {
 mock_repo = conftest.dict_to_obj(mock_repo_dict)
 
 
-# @pytest.fixture
-# def mocked_github_issue_tracker(mocker, tracker_mock):
-#     github_mock = mocker.Mock('github.Github', autospec=True)
-#     mocker.patch('zazu.github_helper.make_gh', return_value=github_mock)
-#     repo_obj_mock = mocker.Mock('github.Repository', autospec=True)
-#     mocker.patch('zazu.plugins.github_issue_tracker.GitHubIssueTracker._github_repo', return_value=[mock_repo])
-#     tracker_mock._github = repo_obj_mock
-#     return tracker_mock
-#
-
-#
-#
-# def test_github_issue_tracker_issue(mocker, mocked_github_issue_tracker):
-#     mocked_github_issue_tracker._github.get_issue = mocker.Mock(return_value=mock_issue)
-#     mocked_github_issue_tracker.connect()
-#     mocked_github_issue_tracker.issue('1')
-#     assert mocked_github_issue_tracker._github.get_issue.call_count == 1
-#     mocked_github_issue_tracker._github.get_issue.assert_called_once_with(1)
-#
-#
-# def test_github_issue_tracker_issue_error(mocker, mocked_github_issue_tracker):
-#     mocked_github_issue_tracker._github.get_issue = mocker.Mock(side_effect=github.GithubException(404, {}))
-#     with pytest.raises(zazu.issue_tracker.IssueTrackerError) as e:
-#         mocked_github_issue_tracker.issue('1')
-#     assert '404' in str(e.value)
-#
-#
-# def test_github_issue_tracker_create_issue_error(mocker, mocked_github_issue_tracker):
-#     mocked_github_issue_tracker._github.create_issue = mocker.Mock(side_effect=github.GithubException(404, {}))
-#     with pytest.raises(zazu.issue_tracker.IssueTrackerError) as e:
-#         mocked_github_issue_tracker.create_issue('', '', '', '', '')
-#     assert '404' in str(e.value)
-#
-#
-# def test_github_issue_tracker_create_issue(mocker, mocked_github_issue_tracker):
-#     mocked_github_issue_tracker._github.create_issue = mocker.Mock(return_value=mock_issue)
-#     mocked_github_issue_tracker.create_issue('project', 'issue_type', 'summary', 'description', 'component')
-#     zazu.plugins.github_issue_tracker.GitHubIssueTracker._github_repo.create_issue.call_count == 1
-#
-
-
 def test_github_scm_host_get_repos(mocker, scm_host_mock):
     github_mock = mocker.Mock('github.Github', autospec=True)
     user_mock = mocker.Mock('github.NamedUser.NamedUser', autospec=True)

--- a/tests/test_github_scm_host.py
+++ b/tests/test_github_scm_host.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+import conftest
+import github
+import pytest
+import zazu.github_helper
+import zazu.plugins.github_scm_host
+
+__author__ = "Nicholas Wiles"
+__copyright__ = "Copyright 2016"
+
+
+@pytest.fixture
+def scm_host_mock(mocker):
+    return zazu.plugins.github_scm_host.GitHubScmHost('stopthatcow')
+
+
+mock_repo_dict = {
+    'name': 'zazu',
+    'full_name': 'stopthatcow/zazu',
+    'description': 'description',
+    'html_url': 'https://github.com/stopthatcow/zazu',
+    'ssh_url': 'ssh://git@github.com/stopthatcow/zazu'
+}
+mock_repo = conftest.dict_to_obj(mock_repo_dict)
+
+
+# @pytest.fixture
+# def mocked_github_issue_tracker(mocker, tracker_mock):
+#     github_mock = mocker.Mock('github.Github', autospec=True)
+#     mocker.patch('zazu.github_helper.make_gh', return_value=github_mock)
+#     repo_obj_mock = mocker.Mock('github.Repository', autospec=True)
+#     mocker.patch('zazu.plugins.github_issue_tracker.GitHubIssueTracker._github_repo', return_value=[mock_repo])
+#     tracker_mock._github = repo_obj_mock
+#     return tracker_mock
+#
+
+#
+#
+# def test_github_issue_tracker_issue(mocker, mocked_github_issue_tracker):
+#     mocked_github_issue_tracker._github.get_issue = mocker.Mock(return_value=mock_issue)
+#     mocked_github_issue_tracker.connect()
+#     mocked_github_issue_tracker.issue('1')
+#     assert mocked_github_issue_tracker._github.get_issue.call_count == 1
+#     mocked_github_issue_tracker._github.get_issue.assert_called_once_with(1)
+#
+#
+# def test_github_issue_tracker_issue_error(mocker, mocked_github_issue_tracker):
+#     mocked_github_issue_tracker._github.get_issue = mocker.Mock(side_effect=github.GithubException(404, {}))
+#     with pytest.raises(zazu.issue_tracker.IssueTrackerError) as e:
+#         mocked_github_issue_tracker.issue('1')
+#     assert '404' in str(e.value)
+#
+#
+# def test_github_issue_tracker_create_issue_error(mocker, mocked_github_issue_tracker):
+#     mocked_github_issue_tracker._github.create_issue = mocker.Mock(side_effect=github.GithubException(404, {}))
+#     with pytest.raises(zazu.issue_tracker.IssueTrackerError) as e:
+#         mocked_github_issue_tracker.create_issue('', '', '', '', '')
+#     assert '404' in str(e.value)
+#
+#
+# def test_github_issue_tracker_create_issue(mocker, mocked_github_issue_tracker):
+#     mocked_github_issue_tracker._github.create_issue = mocker.Mock(return_value=mock_issue)
+#     mocked_github_issue_tracker.create_issue('project', 'issue_type', 'summary', 'description', 'component')
+#     zazu.plugins.github_issue_tracker.GitHubIssueTracker._github_repo.create_issue.call_count == 1
+#
+
+
+def test_github_scm_host_get_repos(mocker, scm_host_mock):
+    github_mock = mocker.Mock('github.Github', autospec=True)
+    user_mock = mocker.Mock('github.NamedUser.NamedUser', autospec=True)
+    github_mock.get_user = mocker.Mock('github.Github.get_user', autospec=True, return_value=user_mock)
+    user_mock.get_repos = mocker.Mock('github.NamedUser.NamedUser.get_repos', autospec=True, return_value=[mock_repo])
+    mocker.patch('zazu.github_helper.make_gh', return_value=github_mock)
+    scm_host_mock.connect()
+    repos = list(scm_host_mock.repos())
+    github_mock.get_user.assert_called_once_with('stopthatcow')
+    user_mock.get_repos.assert_called_once()
+    assert len(repos) == 1
+    assert repos[0].name == 'zazu'
+
+
+def test_github_scm_host_get_repos_error(mocker, scm_host_mock):
+    github_mock = mocker.Mock('github.Github', autospec=True)
+    user_mock = mocker.Mock('github.NamedUser.NamedUser', autospec=True)
+    github_mock.get_user = mocker.Mock('github.Github.get_user', autospec=True, return_value=user_mock)
+    user_mock.get_repos = mocker.Mock('github.NamedUser.NamedUser.get_repos', autospec=True, side_effect=github.GithubException(404, {}))
+    mocker.patch('zazu.github_helper.make_gh', return_value=github_mock)
+    scm_host_mock.connect()
+    with pytest.raises(zazu.scm_host.ScmHostError) as e:
+        list(scm_host_mock.repos())
+    assert '404' in str(e.value)
+
+
+def test_from_config(git_repo):
+    with zazu.util.cd(git_repo.working_tree_dir):
+        uut = zazu.plugins.github_scm_host.GitHubScmHost.from_config({'user': 'stopthatcow',
+                                                                      'type': 'github'})
+        assert uut._user == 'stopthatcow'
+
+
+def test_github_scm_host_repo_adaptor():
+    uut = zazu.plugins.github_scm_host.GitHubScmRepoAdaptor(mock_repo)
+    assert uut.name == 'zazu'
+    assert uut.description == 'description'
+    assert uut.id == 'stopthatcow/zazu'
+    assert uut.browse_url == 'https://github.com/stopthatcow/zazu'
+    assert uut.ssh_url == 'ssh://git@github.com/stopthatcow/zazu'
+    assert str(uut) == uut.id
+    assert repr(uut) == uut.id

--- a/tests/test_jira_issue_tracker.py
+++ b/tests/test_jira_issue_tracker.py
@@ -138,3 +138,4 @@ def test_jira_issue_adaptor(tracker_mock):
     assert uut.browse_url == 'https://jira/browse/ZZ-1'
     assert uut.id == 'ZZ-1'
     assert str(uut) == uut.id
+    assert repr(uut) == uut.id

--- a/tests/test_repo_commands.py
+++ b/tests/test_repo_commands.py
@@ -3,7 +3,7 @@ import click.testing
 import git
 import os
 import tests.conftest
-import yaml
+import ruamel.yaml as yaml
 import zazu.cli
 import zazu.git_helper
 
@@ -70,9 +70,9 @@ def test_cleanup_remote(git_repo_with_local_origin, mocker):
     dir = git_repo.working_tree_dir
     with zazu.util.cd(dir):
         with open('zazu.yaml', 'a') as file:
-            file.write(yaml.dump({'issueTracker': {'type': 'github',
-                                                   'owner': 'foo',
-                                                   'repo': 'bar'}}))
+            yaml.dump({'issueTracker': {'type': 'github',
+                                        'owner': 'foo',
+                                        'repo': 'bar'}}, file)
         git_repo.git.checkout('HEAD', b='develop')
         git_repo.git.checkout('HEAD', b='feature/F00-1')
         with open('README.md', 'w') as f:

--- a/tests/test_repo_commands.py
+++ b/tests/test_repo_commands.py
@@ -130,12 +130,12 @@ def test_clone(mocker, git_repo):
 def test_clone_hosted(mocker, git_repo):
     mocker.patch('git.Repo.clone_from', return_value=git_repo)
     mocker.patch('zazu.config.Config.default_scm_host', return_value='foo')
-    moch_scm_host = mocker.patch('zazu.scm_host.ScmHost', autospec=True)
+    mock_scm_host = mocker.patch('zazu.scm_host.ScmHost', autospec=True)
     mock_host_repo = conftest.dict_to_obj({'id': 'bar',
                                            'ssh_url': 'http://github.com/foo/bar.git'})
-    moch_scm_host.repos = mocker.Mock(return_value=[mock_host_repo])
+    mock_scm_host.repos = mocker.Mock(return_value=[mock_host_repo])
 
-    mocker.patch('zazu.config.Config.scm_hosts', return_value={'foo': moch_scm_host})
+    mocker.patch('zazu.config.Config.scm_hosts', return_value={'foo': mock_scm_host})
     dir = git_repo.working_tree_dir
     with zazu.util.cd(dir):
         runner = click.testing.CliRunner()
@@ -144,6 +144,23 @@ def test_clone_hosted(mocker, git_repo):
     git.Repo.clone_from.assert_called_once()
     assert git.Repo.clone_from.call_args[0][0] == 'http://github.com/foo/bar.git'
     assert 'bar' == git.Repo.clone_from.call_args[0][1]
+    # No matching repo.
+    result = runner.invoke(zazu.cli.cli, ['repo', 'clone', 'foo/baz'])
+    assert result.exit_code != 0
+    # No matching host.
+    result = runner.invoke(zazu.cli.cli, ['repo', 'clone', 'foo2/baz'])
+    assert result.exit_code != 0
+
+
+def test_clone_no_hosted_hosted(mocker, git_repo):
+    mocker.patch('zazu.config.Config.scm_hosts', return_value={})
+    dir = git_repo.working_tree_dir
+    with zazu.util.cd(dir):
+        runner = click.testing.CliRunner()
+        result = runner.invoke(zazu.cli.cli, ['repo', 'clone', 'foo/bar'])
+        assert result.exit_code != 0
+        assert result.exception
+        assert result.output.startswith('Error: Unable to clone foo/bar')
 
 
 def test_clone_error(mocker, git_repo):

--- a/tests/test_scm_host.py
+++ b/tests/test_scm_host.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import pytest
+import zazu.scm_host
+
+__author__ = "Nicholas Wiles"
+__copyright__ = "Copyright 2017"
+
+
+def test_scm_host_repo():
+    uut = zazu.scm_host.ScmHostRepo()
+    with pytest.raises(NotImplementedError):
+        uut.name
+    with pytest.raises(NotImplementedError):
+        uut.id
+    with pytest.raises(NotImplementedError):
+        uut.description
+    with pytest.raises(NotImplementedError):
+        uut.browse_url
+    with pytest.raises(NotImplementedError):
+        uut.ssh_url

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -33,7 +33,7 @@ def repo_with_style_errors(repo_with_style):
 @pytest.mark.skipif(not distutils.spawn.find_executable('astyle'),
                     reason="requires astyle")
 def test_astyle():
-    styler = zazu.plugins.astyle_styler.AstyleStyler(options=['-U'])
+    styler = zazu.plugins.astyle_styler.AstyleStyler(options=['-unpad‑paren'])
     ret = styler.style_string('void main ( ) {}')
     assert ret == 'void main() {}'
     assert styler.default_extensions()

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -33,7 +33,7 @@ def repo_with_style_errors(repo_with_style):
 @pytest.mark.skipif(not distutils.spawn.find_executable('astyle'),
                     reason="requires astyle")
 def test_astyle():
-    styler = zazu.plugins.astyle_styler.AstyleStyler(options=['-unpad-paren'])
+    styler = zazu.plugins.astyle_styler.AstyleStyler(options=['--unpad-paren'])
     ret = styler.style_string('void main ( ) {}')
     assert ret == 'void main() {}'
     assert styler.default_extensions()

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -33,7 +33,7 @@ def repo_with_style_errors(repo_with_style):
 @pytest.mark.skipif(not distutils.spawn.find_executable('astyle'),
                     reason="requires astyle")
 def test_astyle():
-    styler = zazu.plugins.astyle_styler.AstyleStyler(options=['-unpad‑paren'])
+    styler = zazu.plugins.astyle_styler.AstyleStyler(options=['-unpad-paren'])
     ret = styler.style_string('void main ( ) {}')
     assert ret == 'void main() {}'
     assert styler.default_extensions()

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -30,12 +30,12 @@ def repo_with_style_errors(repo_with_style):
     return repo_with_style
 
 
-@pytest.mark.skipif(not distutils.spawn.find_executable('astyle'),
-                    reason="requires astyle")
-def test_astyle():
-    styler = zazu.plugins.astyle_styler.AstyleStyler(options=['--unpad-paren'])
-    ret = styler.style_string('void main ( ) {}')
-    assert ret == 'void main() {}'
+def test_astyle(mocker):
+    mocker.patch('zazu.util.check_popen', return_value='bar')
+    styler = zazu.plugins.astyle_styler.AstyleStyler(options=['-U'])
+    ret = styler.style_string('foo')
+    zazu.util.check_popen.assert_called_once_with(args=['astyle', '-U'], stdin_str='foo')
+    assert ret == 'bar'
     assert styler.default_extensions()
 
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -3,7 +3,7 @@ import click.testing
 import os
 import pip
 import pytest
-import yaml
+import ruamel.yaml as yaml
 import zazu.cli
 
 __author__ = "Nicholas Wiles"
@@ -17,7 +17,7 @@ def config_with_required_zazu(git_repo):
         'zazu': '1.2.3'
     }
     with open(os.path.join(root, 'zazu.yaml'), 'a') as file:
-        file.write(yaml.dump(zazu_version_config))
+        yaml.dump(zazu_version_config, file)
     return git_repo
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import click
+import inquirer
 import os
 import pytest
 import subprocess

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -144,4 +144,4 @@ def test_flatten_dict():
 
 
 def test_unflatten_dict():
-    assert UNFLATTENED_DICT == zazu.util.flatten_dict(FLATTENED_DICT)
+    assert UNFLATTENED_DICT == zazu.util.unflatten_dict(FLATTENED_DICT)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -150,6 +150,27 @@ def test_unflatten_dict():
     assert UNFLATTENED_DICT == zazu.util.unflatten_dict(FLATTENED_DICT)
 
 
+def test_dict_get_nested():
+    d = {'a': {'b': 's', 'c': {'d': 'e'}}}
+    assert zazu.util.dict_get_nested(d, ['a', 'b'], None) == 's'
+    assert zazu.util.dict_get_nested(d, ['a', 'c'], None) == {'d': 'e'}
+    assert zazu.util.dict_get_nested(d, ['a', 'c', 'e'], None) is None
+
+
+def test_dict_del_nested():
+    d = {'a': {'b': 's', 'c': {'d': 'e'}}}
+    zazu.util.dict_del_nested(d, ['a', 'b'])
+    assert d == {'a': {'c': {'d': 'e'}}}
+    zazu.util.dict_del_nested(d, ['a'])
+    assert d == {}
+
+
+def test_dict_update_nested():
+    d = {'a': {'b': 's', 'c': {'d': 'e'}}}
+    zazu.util.dict_update_nested(d, {'a': {'b': {'c': 'd'}}})
+    assert d == {'a': {'b': {'c': 'd'}, 'c': {'d': 'e'}}}
+
+
 def test_readline_fallback(mocker):
     old_import = __import__
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -133,3 +133,15 @@ def test_pick_interupted(monkeypatch):
     monkeypatch.setattr('inquirer.prompt', lambda x: None)
     with pytest.raises(KeyboardInterrupt):
         zazu.util.pick(choices, 'foo')
+
+
+UNFLATTENED_DICT = {'a': {'b': {'c': 5}, 'd': 6}}
+FLATTENED_DICT = {'a.b.c': 5, 'a.d.': 6}
+
+
+def test_flatten_dict():
+    assert FLATTENED_DICT == zazu.util.flatten_dict(UNFLATTENED_DICT)
+
+
+def test_unflatten_dict():
+    assert UNFLATTENED_DICT == zazu.util.flatten_dict(FLATTENED_DICT)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -136,7 +136,7 @@ def test_pick_interupted(monkeypatch):
 
 
 UNFLATTENED_DICT = {'a': {'b': {'c': 5}, 'd': 6}}
-FLATTENED_DICT = {'a.b.c': 5, 'a.d.': 6}
+FLATTENED_DICT = {'a.b.c': 5, 'a.d': 6}
 
 
 def test_flatten_dict():

--- a/zazu.yaml
+++ b/zazu.yaml
@@ -31,9 +31,9 @@ codeReviewer:
 style:
   include:
     - setup.py
-    - docs/**/*.py
-    - tests/**/*.py
-    - zazu/**/*.py
+    - docs/**.py
+    - tests/**.py
+    - zazu/**.py
   autopep8:
     options:
       - "--max-line-length=150"

--- a/zazu/cli.py
+++ b/zazu/cli.py
@@ -31,6 +31,7 @@ def init():
 cli.add_command(zazu.upgrade.upgrade)
 cli.add_command(zazu.style.style)
 cli.add_command(zazu.build.build)
+cli.add_command(zazu.config.config)
 cli.add_command(zazu.dev.commands.dev)
 cli.add_command(zazu.repo.commands.repo)
 init()

--- a/zazu/config.py
+++ b/zazu/config.py
@@ -163,7 +163,7 @@ def find_and_load_yaml_file(search_paths, file_names):
 
 
 def user_config_filepath():
-    return os.path.join(os.path.expanduser("~"), '.zazuconfig')
+    return os.path.join(os.path.expanduser("~"), '.zazuconfig.yaml')
 
 
 class Config(object):
@@ -298,13 +298,13 @@ class Config(object):
             raise click.UsageError('The current working directory is not in a git repo')
 
 
-DEFAULT_USER_CONFIG = """# Default user configuration for zazu
+DEFAULT_USER_CONFIG = """  # User configuration file for zazu.
 
-# scm:
-#  github:
-#    type: github
-#    user: username
-
+# SCM hosts are cloud hosting services for repos. Currently GitHub is supported.
+# scmHost:
+#    default:                # This is the default SCM host.
+#        type: github        # Type of this SCM host.
+#        user: user          # GitHub username
 """
 
 

--- a/zazu/config.py
+++ b/zazu/config.py
@@ -280,8 +280,10 @@ class Config(object):
         """Parse and return the global zazu yaml configuration file."""
         if self._user_config is None:
             user_config_path = user_config_filepath()
-            maybe_write_default_user_config(user_config_path)
-            self._user_config = load_yaml_file(user_config_path)
+            try:
+                self._user_config = load_yaml_file(user_config_path)
+            except IOError:
+                self._user_config = None
             if self._user_config is None:
                 self._user_config = {}
         return self._user_config

--- a/zazu/config.py
+++ b/zazu/config.py
@@ -294,7 +294,7 @@ def config(ctx, list, edit, add, unset, show_origin, param_name, param_value):
     if add and param_value is None:
         raise click.UsageError('--add requires a param value')
     if (list or show_origin) and param_name is not None:
-        raise click.UsageError('--list and --show_origin can\'t be used with a param name')
+        raise click.UsageError('--list and --show-origin can\'t be used with a param name')
 
     user_config_path = user_config_filepath()
     if not os.path.isfile(user_config_path):
@@ -307,8 +307,8 @@ def config(ctx, list, edit, add, unset, show_origin, param_name, param_value):
 
     if list or show_origin:
         source = '{}\t'.format(user_config_path) if show_origin else ''
-        for k, v in flattened.items():
-            print('{}{}={}'.format(source, k, v))
+        for k in sorted(flattened):
+            click.echo('{}{}={}'.format(source, k, flattened[k]))
 
     elif edit:
         while True:
@@ -328,8 +328,9 @@ def config(ctx, list, edit, add, unset, show_origin, param_name, param_value):
                 ctx.exit(-1)
             if unset:
                 del flattened[param_name]
+                write_config = True
             else:
-                print(param_value)
+                click.echo(param_value)
                 return
         else:
             # Write the new parameter value.

--- a/zazu/config.py
+++ b/zazu/config.py
@@ -229,6 +229,7 @@ DEFAULT_USER_CONFIG = """ \
 
 """
 
+
 @click.command()
 @click.pass_context
 @click.option('-l', '--list', is_flag=True, help='list config')
@@ -248,5 +249,3 @@ def config(ctx, list, edit, show_origin):
         flattened = zazu.util.flatten_dict(config_dict)
         for k, v in flattened.items():
             print('{}{}={}'.format(source, k, v))
-
-

--- a/zazu/issue_tracker.py
+++ b/zazu/issue_tracker.py
@@ -54,3 +54,11 @@ class Issue(object):
     def id(self):
         """Get the string id of the issue."""
         raise NotImplementedError('Must implement id')
+
+    def __str__(self):
+        """Return the id as the string representation."""
+        return self.id
+
+    def __repr__(self):
+        """Return the id as the string representation."""
+        return self.id

--- a/zazu/plugins/github_issue_tracker.py
+++ b/zazu/plugins/github_issue_tracker.py
@@ -169,7 +169,3 @@ class GitHubIssueAdaptor(zazu.issue_tracker.Issue):
     def id(self):
         """Get the string id of the issue."""
         return str(self._github_issue.number)
-
-    def __str__(self):
-        """Return the id as the string representation."""
-        return self.id

--- a/zazu/plugins/github_scm_host.py
+++ b/zazu/plugins/github_scm_host.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Clasess that adapt GitHub for use as a zazu VersionControlHost."""
+"""Clasess that adapt GitHub for use as a zazu ScmHost."""
 import zazu.github_helper
 import zazu.scm_host
 import zazu.util
@@ -12,11 +12,11 @@ __author__ = "Nicholas Wiles"
 __copyright__ = "Copyright 2016"
 
 
-class GitHubVersionControlHost(zazu.scm_host.ScmHost):
-    """Implements zazu VersionControlHost interface for GitHub."""
+class GitHubScmHost(zazu.scm_host.ScmHost):
+    """Implements zazu SCM host interface for GitHub."""
 
     def __init__(self, user):
-        """Create a GitHubVersionControlHost.
+        """Create a GitHubScmHost.
 
         Args:
             user (str): the github username.
@@ -43,13 +43,13 @@ class GitHubVersionControlHost(zazu.scm_host.ScmHost):
 
     @staticmethod
     def from_config(config):
-        """Make a GitHubVersionControlHost from a config."""
+        """Make a GitHubScmHost from a config."""
         # Get URL from current git repo:
-        return GitHubVersionControlHost(user=config['user'])
+        return GitHubScmHost(user=config['user'])
 
     @staticmethod
     def type():
-        """Return the name of this VersionControlHost type."""
+        """Return the name of this ScmHost type."""
         return 'github'
 
 
@@ -81,7 +81,7 @@ class GitHubScmRepoAdaptor(zazu.scm_host.ScmHostRepo):
 
     @property
     def browse_url(self):
-        """Get the url to open to display the issue."""
+        """Get the url to open to display the repo."""
         return self._github_repo.html_url
 
     @property

--- a/zazu/plugins/github_scm_host.py
+++ b/zazu/plugins/github_scm_host.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Clasess that adapt GitHub for use as a zazu VersionControlHost."""
+import zazu.github_helper
+import zazu.scm_host
+import zazu.util
+zazu.util.lazy_import(locals(), [
+    'github',
+    'os'
+])
+
+__author__ = "Nicholas Wiles"
+__copyright__ = "Copyright 2016"
+
+
+class GitHubVersionControlHost(zazu.scm_host.ScmHost):
+    """Implements zazu VersionControlHost interface for GitHub."""
+
+    def __init__(self, user):
+        """Create a GitHubVersionControlHost.
+
+        Args:
+            user (str): the github username.
+        """
+        self._user = user
+        self._github_handle = None
+
+    def connect(self):
+        """Get handle to ensure that github credentials are in place."""
+        self._github()
+
+    def _github(self):
+        if self._github_handle is None:
+            self._github_handle = zazu.github_helper.make_gh()
+        return self._github_handle
+
+    def repos(self):
+        """List repos available to this user."""
+        try:
+            for r in self._github().get_user(self._user).get_repos():
+                yield GitHubScmRepoAdaptor(r)
+        except github.GithubException as e:
+            raise zazu.scm_host.ScmHostError(str(e))
+
+    @staticmethod
+    def from_config(config):
+        """Make a GitHubVersionControlHost from a config."""
+        # Get URL from current git repo:
+        return GitHubVersionControlHost(user=config['user'])
+
+    @staticmethod
+    def type():
+        """Return the name of this VersionControlHost type."""
+        return 'github'
+
+
+class GitHubScmRepoAdaptor(zazu.scm_host.ScmHostRepo):
+    """Wraps a repo returned from the GirHub api and adapts it to the zazu.scm_host.ScmHostRepo interface."""
+
+    def __init__(self, github_repo):
+        """Create a GitHubScmRepoAdaptor by wrapping a GitHub Repo object.
+
+        Args:
+            github_repo: GitHub repo handle.
+        """
+        self._github_repo = github_repo
+
+    @property
+    def name(self):
+        """Get the name of the repo."""
+        return self._github_repo.name
+
+    @property
+    def id(self):
+        """Get the full name of the repo as the id."""
+        return self._github_repo.full_name
+
+    @property
+    def description(self):
+        """Get the description of the repo."""
+        return self._github_repo.description
+
+    @property
+    def browse_url(self):
+        """Get the url to open to display the issue."""
+        return self._github_repo.html_url
+
+    @property
+    def ssh_url(self):
+        """Get the ssh url to clone the repo."""
+        return self._github_repo.ssh_url

--- a/zazu/plugins/jira_issue_tracker.py
+++ b/zazu/plugins/jira_issue_tracker.py
@@ -195,7 +195,3 @@ class JiraIssueAdaptor(zazu.issue_tracker.Issue):
     def id(self):
         """Get the string id of the issue."""
         return self._jira_issue.key
-
-    def __str__(self):
-        """Return the id as the string representation."""
-        return self.id

--- a/zazu/repo/commands.py
+++ b/zazu/repo/commands.py
@@ -54,19 +54,27 @@ def ci(ctx):
 
 
 @repo.command()
-@click.argument('repository_url')
+@click.argument('repository')
+@click.argument('destination', required=False)
 @click.option('--nohooks', is_flag=True, help='does not install git hooks in the cloned repo')
 @click.option('--nosubmodules', is_flag=True, help='does not update submodules')
-def clone(repository_url, nohooks, nosubmodules):
+@click.pass_context
+def clone(ctx, repository, destination, nohooks, nosubmodules):
     """Clone and initialize a repo.
 
     Args:
-        repository_url (str): url of the repository to clone.
+        repository (str): name or url of the repository to clone.
+        destination (str): path to clone the repo to.
         nohooks (bool): if True, git hooks are not installed.
         nosubmodules (bool): if True submodules are not initialized.
     """
     try:
-        destination = '{}/{}'.format(os.getcwd(), repository_url.rsplit('/', 1)[-1].replace('.git', ''))
+        scm_repo = ctx.obj.scm_host_repo(repository)
+        repository_url = scm_repo.ssh_url if scm_repo is not None else repository
+
+        if destination is None:
+            destination = repository_url.rsplit('/', 1)[-1].replace('.git', '')
+        click.echo('Cloning {} into {}'.format(repository_url, destination))
         repo = git.Repo.clone_from(repository_url, destination)
         click.echo('Repository successfully cloned')
 

--- a/zazu/repo/commands.py
+++ b/zazu/repo/commands.py
@@ -70,11 +70,16 @@ def clone(ctx, repository, destination, nohooks, nosubmodules):
     """
     try:
         scm_repo = ctx.obj.scm_host_repo(repository)
-        repository_url = scm_repo.ssh_url if scm_repo is not None else repository
+    except click.ClickException:
+        scm_repo = None
 
-        if destination is None:
-            destination = repository_url.rsplit('/', 1)[-1].replace('.git', '')
-        click.echo('Cloning {} into {}'.format(repository_url, destination))
+    repository_url = scm_repo.ssh_url if scm_repo is not None else repository
+
+    if destination is None:
+        destination = repository_url.rsplit('/', 1)[-1].replace('.git', '')
+    click.echo('Cloning {} into {}'.format(repository_url, destination))
+
+    try:
         repo = git.Repo.clone_from(repository_url, destination)
         click.echo('Repository successfully cloned')
 

--- a/zazu/repo/commands.py
+++ b/zazu/repo/commands.py
@@ -54,13 +54,6 @@ def ci(ctx):
 
 
 @repo.command()
-@click.pass_context
-def list(ctx):
-    for name, host in ctx.obj.scm_hosts().iteritems():
-        print('Host {}: {}'.format(name, zazu.util.pprint_list(host.repos())))
-
-
-@repo.command()
 @click.argument('repository_url')
 @click.option('--nohooks', is_flag=True, help='does not install git hooks in the cloned repo')
 @click.option('--nosubmodules', is_flag=True, help='does not update submodules')

--- a/zazu/repo/commands.py
+++ b/zazu/repo/commands.py
@@ -54,6 +54,13 @@ def ci(ctx):
 
 
 @repo.command()
+@click.pass_context
+def list(ctx):
+    for name, host in ctx.obj.scm_hosts().iteritems():
+        print('Host {}: {}'.format(name, zazu.util.pprint_list(host.repos())))
+
+
+@repo.command()
 @click.argument('repository_url')
 @click.option('--nohooks', is_flag=True, help='does not install git hooks in the cloned repo')
 @click.option('--nosubmodules', is_flag=True, help='does not update submodules')

--- a/zazu/scm_host.py
+++ b/zazu/scm_host.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Source code management (SCM) host related classes."""
+__author__ = "Nicholas Wiles"
+__copyright__ = "Copyright 2018"
+
+
+class ScmHost(object):
+    """Parent of all ScmHost objects."""
+
+
+class ScmHostError(Exception):
+    """Parent of all ScmHost errors."""
+
+
+class ScmHostRepo(object):
+    """Parent of all SCM repos."""
+
+    @property
+    def name(self):
+        """Get the name of the repo."""
+        raise NotImplementedError('Must implement name')
+
+    @property
+    def id(self):
+        """Get the id of the repo."""
+        raise NotImplementedError('Must implement id')
+
+    @property
+    def description(self):
+        """Get the description of the repo."""
+        raise NotImplementedError('Must implement description')
+
+    @property
+    def browse_url(self):
+        """Get the url to open to display the repo."""
+        raise NotImplementedError('Must implement browse_url')
+
+    @property
+    def ssh_url(self):
+        """Get the ssh url to clone the repo."""
+        raise NotImplementedError('Must implement ssh_url')
+
+    def __str__(self):
+        """Return the id as the string representation."""
+        return self.id
+
+    def __repr__(self):
+        """Return the id as the string representation."""
+        return self.id

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -272,21 +272,6 @@ def unflatten_dict(d, separator='.'):
     return ret
 
 
-def open_file(filepath):
-    """Open a file.
-
-    Args: filepath: the file to open.
-    """
-    if sys.platform.startswith('darwin'):
-        subprocess.call(('open', filepath))
-    elif os.name == 'nt':
-        os.startfile(filepath)
-    elif os.name == 'posix':
-        subprocess.call(('xdg-open', filepath))
-    else:
-        raise click.ClickException('Not sure how to open a file on this machine')
-
-
 def raise_uninstalled(pkg_name):
     """Raise an exception for a missing package.
 

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -229,6 +229,8 @@ def pprint_list(data):
 def flatten_dict(d, separator='.', prefix=''):
     """Flatten nested dictionary.
 
+    Transforms {'a': {'b': {'c': 5}, 'd': 6}} into {'a.b.c': 5, 'a.d': 6}
+
     Args:
         d (dist): nested dictionary to flatten.
         separator (str): the separator to use between keys.
@@ -247,13 +249,15 @@ def flatten_dict(d, separator='.', prefix=''):
 def unflatten_dict(d, separator='.'):
     """Unflatten nested dictionary.
 
+    Transforms {'a.b.c': 5, 'a.d': 6} into {'a': {'b': {'c': 5}, 'd': 6}}
+
     Args:
-        d (dist): nested dictionary to flatten.
+        d (dict): nested dictionary to flatten.
         separator (str): the separator to use between keys.
         prefix (str): key prefix
 
     Returns:
-        dict: a expanded dictionary with keys uncompressed and unseparated by separator.
+        dict: a expanded dictionary with keys uncompressed.
 
     """
     ret = dict()

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -225,6 +225,23 @@ def pprint_list(data):
     return '\n  - {}'.format('\n  - '.join(data))
 
 
+def flatten_dict(d, separator='.', prefix=''):
+    """Flatten nested dictionary.
+
+    Args:
+        d (dist): nested dictionary to flatten.
+        separator (str): the separator to use between keys.
+        prefix (str): key prefix
+    Returns:
+        dict: a dictionary with keys compressed and separated by separator.
+
+    """
+    return { prefix + separator + k if prefix else k : v
+             for kk, vv in d.items()
+             for k, v in flatten_dict(vv, separator, kk).items()
+             } if isinstance(d, dict) else { prefix : d }
+
+
 def raise_uninstalled(pkg_name):
     """Raise an exception for a missing package.
 

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -223,7 +223,7 @@ def pprint_list(data):
         str: a newline separated pretty printed list.
 
     """
-    return '\n  - {}'.format('\n  - '.join(data))
+    return '\n  - {}'.format('\n  - '.join(str(x) for x in data))
 
 
 def flatten_dict(d, separator='.', prefix=''):

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -38,6 +38,7 @@ lazy_import(locals(), [
     'click',
     'concurrent.futures',
     'contextlib',
+    'dict_recursive_update',
     'fnmatch',
     'inquirer',
     'multiprocessing',
@@ -270,6 +271,55 @@ def unflatten_dict(d, separator='.'):
             d = d[part]
         d[parts[-1]] = value
     return ret
+
+
+def dict_get_nested(d, keys, alt_ret):
+    """Get a nested dictionary entry given a list of keys.
+
+    Equivalent to d[keys[0]][keys[1]]...etc.
+
+    Args:
+        d (dict): nested dictionary to search.
+        keys (list): keys to search one by one.
+        alt_ret: returned if the specified item is not found.
+
+    Returns:
+          item matching the chain of keys in d.
+    """
+    item = d.get(keys[0], alt_ret)
+    for k in keys[1:]:
+        item = item.get(k, alt_ret)
+    return item
+
+
+def dict_del_nested(d, keys):
+    """Delete a nested dictionary entry given a list of keys.
+
+    Equivalent to del d[keys[0]][keys[1]]...etc.
+
+    Args:
+        d (dict): nested dictionary to search.
+        keys (list): keys to search one by one.
+
+    Raises:
+        KeyError: if the key couldn't be found in d.
+    """
+    item = d
+    if keys:
+        for k in keys[:-1]:
+            item = item[k]
+        del item[keys[-1]]
+
+
+def dict_update_nested(d, update):
+    """Updated a nested dictionary given an update dictionary.
+
+    Args:
+        d (dict): dictionary to add the update to.
+        update (dict): update to apply to the dictionary.
+
+    """
+    dict_recursive_update.recursive_update(d, update)
 
 
 def raise_uninstalled(pkg_name):

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -238,10 +238,10 @@ def flatten_dict(d, separator='.', prefix=''):
         dict: a dictionary with keys compressed and separated by separator.
 
     """
-    return { prefix + separator + k if prefix else k : v
-             for kk, vv in d.items()
-             for k, v in flatten_dict(vv, separator, kk).items()
-             } if isinstance(d, dict) else { prefix : d }
+    return {prefix + separator + k if prefix else k: v
+            for kk, vv in d.items()
+            for k, v in flatten_dict(vv, separator, kk).items()
+            } if isinstance(d, dict) else {prefix: d}
 
 
 def open_file(filepath):

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -244,6 +244,30 @@ def flatten_dict(d, separator='.', prefix=''):
             } if isinstance(d, dict) else {prefix: d}
 
 
+def unflatten_dict(d, separator='.'):
+    """Unflatten nested dictionary.
+
+    Args:
+        d (dist): nested dictionary to flatten.
+        separator (str): the separator to use between keys.
+        prefix (str): key prefix
+
+    Returns:
+        dict: a expanded dictionary with keys uncompressed and unseparated by separator.
+
+    """
+    ret = dict()
+    for key, value in d.iteritems():
+        parts = key.split(separator)
+        d = ret
+        for part in parts[:-1]:
+            if part not in d:
+                d[part] = dict()
+            d = d[part]
+        d[parts[-1]] = value
+    return ret
+
+
 def open_file(filepath):
     """Open a file.
 

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -42,7 +42,8 @@ lazy_import(locals(), [
     'inquirer',
     'multiprocessing',
     'os',
-    'subprocess'
+    'subprocess',
+    'sys'
 ])
 __author__ = "Nicholas Wiles"
 __copyright__ = "Copyright 2016"
@@ -232,6 +233,7 @@ def flatten_dict(d, separator='.', prefix=''):
         d (dist): nested dictionary to flatten.
         separator (str): the separator to use between keys.
         prefix (str): key prefix
+
     Returns:
         dict: a dictionary with keys compressed and separated by separator.
 
@@ -240,6 +242,21 @@ def flatten_dict(d, separator='.', prefix=''):
              for kk, vv in d.items()
              for k, v in flatten_dict(vv, separator, kk).items()
              } if isinstance(d, dict) else { prefix : d }
+
+
+def open_file(filepath):
+    """Open a file.
+
+    Args: filepath: the file to open.
+    """
+    if sys.platform.startswith('darwin'):
+        subprocess.call(('open', filepath))
+    elif os.name == 'nt':
+        os.startfile(filepath)
+    elif os.name == 'posix':
+        subprocess.call(('xdg-open', filepath))
+    else:
+        raise click.ClickException('Not sure how to open a file on this machine')
 
 
 def raise_uninstalled(pkg_name):

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -54,7 +54,7 @@ def check_output(*args, **kwargs):
     try:
         return subprocess.check_output(*args, **kwargs)
     except OSError:
-        raise_uninstalled(args[0][0])
+        raise_uninstalled(args[0])
 
 
 def call(*args, **kwargs):
@@ -62,7 +62,7 @@ def call(*args, **kwargs):
     try:
         return subprocess.call(*args, **kwargs)
     except OSError:
-        raise_uninstalled(args[0][0])
+        raise_uninstalled(args[0])
 
 
 def check_popen(args, stdin_str='', *other_args, **kwargs):
@@ -84,7 +84,7 @@ def check_popen(args, stdin_str='', *other_args, **kwargs):
                              *other_args, **kwargs)
         stdout, stderr = p.communicate(stdin_str)
     except OSError:
-        raise_uninstalled(args[0][0])
+        raise_uninstalled(args[0])
     if p.returncode:
         raise subprocess.CalledProcessError(p.returncode, args, stderr)
     return stdout


### PR DESCRIPTION
Add config subcommand and allow config to be used to get clone URLs in `zazu repo clone` the real fun begins once we add autocompletion for this, however this will allow you to do:

`zazu repo clone stopthatcow/click`

Fixes #100