### PR TITLE
Speed up launch time

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include fastentrypoints.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,12 +16,12 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import zazu.build
 import datetime
 import git
 import os
 import sphinx_rtd_theme
 import sys
+import zazu.build
 sys.path.insert(0, os.path.abspath('..'))
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,13 +16,13 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import zazu.build
 import datetime
 import git
 import os
 import sphinx_rtd_theme
 import sys
 sys.path.insert(0, os.path.abspath('..'))
-import zazu.build
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import os
 import sphinx_rtd_theme
 import sys
 sys.path.insert(0, os.path.abspath('..'))
-import zazu.build
+import zazu.repo.commands  # noqa
 
 # -- General configuration ------------------------------------------------
 
@@ -56,7 +56,7 @@ author = u'Nicholas Wiles'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-semver = zazu.build.make_semver('../', 0)
+semver = zazu.repo.commands.make_semver('../', 0)
 pep440_version = zazu.build.pep440_from_semver(semver)
 version = '{}.{}.{}'.format(semver.major, semver.minor, semver.patch)
 if version == '0.0.0':

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -1,0 +1,112 @@
+# noqa: D300,D400
+# Copyright (c) 2016, Aaron Christianson
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+'''
+Monkey patch setuptools to write faster console_scripts with this format:
+
+    import sys
+    from mymodule import entry_function
+    sys.exit(entry_function())
+
+This is better.
+
+(c) 2016, Aaron Christianson
+http://github.com/ninjaaron/fast-entry_points
+'''
+from setuptools.command import easy_install
+import re
+TEMPLATE = r'''
+# -*- coding: utf-8 -*-
+# EASY-INSTALL-ENTRY-SCRIPT: '{3}','{4}','{5}'
+__requires__ = '{3}'
+import re
+import sys
+
+from {0} import {1}
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit({2}())'''.lstrip()
+
+
+@classmethod
+def get_args(cls, dist, header=None):  # noqa: D205,D400
+    """
+    Yield write_script() argument tuples for a distribution's
+    console_scripts and gui_scripts entry points.
+    """
+    if header is None:
+        # pylint: disable=E1101
+        header = cls.get_header()
+    spec = str(dist.as_requirement())
+    for type_ in 'console', 'gui':
+        group = type_ + '_scripts'
+        for name, ep in dist.get_entry_map(group).items():
+            # ensure_safe_name
+            if re.search(r'[\\/]', name):
+                raise ValueError("Path separators not allowed in script names")
+            script_text = TEMPLATE.format(
+                ep.module_name, ep.attrs[0], '.'.join(ep.attrs),
+                spec, group, name)
+            # pylint: disable=E1101
+            args = cls._get_script_args(type_, name, header, script_text)
+            for res in args:
+                yield res
+
+
+# pylint: disable=E1101
+easy_install.ScriptWriter.get_args = get_args
+
+
+def main():
+    import os
+    import re
+    import shutil
+    import sys
+    dests = sys.argv[1:] or ['.']
+    filename = re.sub(r'\.pyc$', '.py', __file__)
+
+    for dst in dests:
+        shutil.copy(filename, dst)
+        manifest_path = os.path.join(dst, 'MANIFEST.in')
+        setup_path = os.path.join(dst, 'setup.py')
+
+        # Insert the include statement to MANIFEST.in if not present
+        with open(manifest_path, 'a+') as manifest:
+            manifest.seek(0)
+            manifest_content = manifest.read()
+            if 'include fastentrypoints.py' not in manifest_content:
+                manifest.write(('\n' if manifest_content else '') +
+                               'include fastentrypoints.py')
+
+        # Insert the import statement to setup.py if not present
+        with open(setup_path, 'a+') as setup:
+            setup.seek(0)
+            setup_content = setup.read()
+            if 'import fastentrypoints' not in setup_content:
+                setup.seek(0)
+                setup.truncate()
+                setup.write('import fastentrypoints\n' + setup_content)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setuptools.setup(
                       'future>=0.16.0',                # MIT
                       'futures>=3.2.0',                # PSF
                       'inquirer>=2.2.0',               # MIT
-                      'Importing>=1.10',               # PSF
                       'straight.plugin>=1.5.0'],       # MIT
     extras_require={
         ':sys_platform == "win32"': [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,16 @@
 # -*- coding: utf-8 -*-
 
+# Work around issue where setuptools creates very slow entry points for non-wheel distributions.
+# See https://pypi.org/project/fastentrypoints/
+try:
+    import fastentrypoints
+except ImportError:
+    from setuptools.command import easy_install
+    import pkg_resources
+    easy_install.main(['fastentrypoints'])
+    pkg_resources.require('fastentrypoints')
+    import fastentrypoints
+
 import setuptools
 import os.path
 import sys
@@ -56,7 +67,7 @@ setuptools.setup(
                       'GitPython>=2.1.8',              # BSD
                       'dict-recursive-update>=1.0.1',  # MIT
                       'ruamel.yaml<=0.15',             # MIT
-                      'keyring<=8.0',                  # MIT
+                      'keyring>=18.0.1',               # MIT
                       'keyrings.alt>=2.3',             # MIT
                       'autopep8>=1.3.4',               # MIT
                       'docformatter>=1.0',             # Expat

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Work around issue where setuptools creates very slow entry points for non-wheel distributions.
-# See https://pypi.org/project/fastentrypoints/
-try:
-    import fastentrypoints
-except ImportError:
-    from setuptools.command import easy_install
-    import pkg_resources
-    easy_install.main(['fastentrypoints'])
-    pkg_resources.require('fastentrypoints')
-    import fastentrypoints
-
+import fastentrypoints  # Work around issue where setuptools creates very slow entry points for non-wheel distributions.
 import setuptools
 import os.path
 import sys

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import cProfile
 import click
 import click.testing
 import distutils.spawn

--- a/zazu/config.py
+++ b/zazu/config.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
 """Config classes and methods for zazu."""
-import zazu.code_reviewer
-import zazu.git_helper
-import zazu.issue_tracker
-import zazu.scm_host
+
 import zazu.util
-# TODO(stopthatcow): Clean these up so they are not enumerated here.
-import zazu.plugins.github_scm_host
-import zazu.plugins.github_issue_tracker
-import zazu.plugins.jira_issue_tracker
-import zazu.plugins.github_code_reviewer
-import zazu.plugins.astyle_styler
-import zazu.plugins.autopep8_styler
-import zazu.plugins.clang_format_styler
-import zazu.plugins.docformatter_styler
-import zazu.plugins.esformatter_styler
-import zazu.plugins.eslint_styler
-import zazu.plugins.generic_styler
-import zazu.plugins.goimports_styler
 zazu.util.lazy_import(locals(), [
     'click',
     'dict_recursive_update',
@@ -26,7 +10,23 @@ zazu.util.lazy_import(locals(), [
     'ruamel.yaml',
     'straight.plugin',
     'subprocess',
-    'sys'
+    'sys',
+    'zazu.code_reviewer',
+    'zazu.git_helper',
+    'zazu.issue_tracker',
+    'zazu.scm_host',
+    'zazu.plugins.github_scm_host',
+    'zazu.plugins.github_issue_tracker',
+    'zazu.plugins.jira_issue_tracker',
+    'zazu.plugins.github_code_reviewer',
+    'zazu.plugins.astyle_styler',
+    'zazu.plugins.autopep8_styler',
+    'zazu.plugins.clang_format_styler',
+    'zazu.plugins.docformatter_styler',
+    'zazu.plugins.esformatter_styler',
+    'zazu.plugins.eslint_styler',
+    'zazu.plugins.generic_styler',
+    'zazu.plugins.goimports_styler',
 ])
 
 __author__ = 'Nicholas Wiles'
@@ -67,12 +67,6 @@ class PluginFactory(object):
                                                                                                 sorted(known_types.keys())))
         else:
             raise click.ClickException('{} config requires a "type" field'.format(self._name))
-
-
-# TODO(stopthatcow): Clean these up so they are not enumerated here.
-issue_tracker_factory = PluginFactory('issueTracker', zazu.issue_tracker.IssueTracker, [zazu.plugins.github_issue_tracker.GitHubIssueTracker,
-                                                                                        zazu.plugins.jira_issue_tracker.JiraIssueTracker])
-code_reviewer_factory = PluginFactory('codeReviewer', zazu.code_reviewer.CodeReviewer, [zazu.plugins.github_code_reviewer.GitHubCodeReviewer])
 
 
 def scm_host_factory(user_config, config):
@@ -255,6 +249,8 @@ class Config(object):
     def issue_tracker(self):
         """Lazily create a IssueTracker object."""
         if self._issue_tracker is None:
+            issue_tracker_factory = PluginFactory('issueTracker', zazu.issue_tracker.IssueTracker, [zazu.plugins.github_issue_tracker.GitHubIssueTracker,
+                                                                                                    zazu.plugins.jira_issue_tracker.JiraIssueTracker])
             self._issue_tracker = issue_tracker_factory.from_config(self.issue_tracker_config())
         return self._issue_tracker
 
@@ -285,6 +281,8 @@ class Config(object):
     def code_reviewer(self):
         """Lazily create and return code reviewer object."""
         if self._code_reviewer is None:
+            code_reviewer_factory = PluginFactory('codeReviewer', zazu.code_reviewer.CodeReviewer, [
+                                                  zazu.plugins.github_code_reviewer.GitHubCodeReviewer])
             self._code_reviewer = code_reviewer_factory.from_config(self.code_reviewer_config())
         return self._code_reviewer
 

--- a/zazu/dev/commands.py
+++ b/zazu/dev/commands.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Dev subcommand for zazu."""
 
-import zazu.github_helper
-import zazu.config
 import zazu.util
 zazu.util.lazy_import(locals(), [
     'click',
@@ -11,7 +9,9 @@ zazu.util.lazy_import(locals(), [
     'os',
     'webbrowser',
     'textwrap',
-    'urllib'
+    'urllib',
+    'zazu.github_helper',
+    'zazu.config',
 ])
 
 __author__ = 'Nicholas Wiles'

--- a/zazu/imports.py
+++ b/zazu/imports.py
@@ -1,0 +1,230 @@
+"""Tools for doing dynamic imports Modified from https://github.com/PEAK-Legacy/Importing."""
+
+__all__ = [
+    'lazyModule', 'joinPath', 'whenImported', 'getModuleHooks',
+]
+
+from types import ModuleType
+try:
+    from types import StringTypes
+except ImportError:
+    StringTypes = str
+from sys import modules
+from imp import acquire_lock, release_lock
+
+
+class AlreadyRead(Exception):
+    pass
+
+
+try:
+    exec("def reraise(t, v, tb): raise t, v, tb")
+except SyntaxError:
+    def reraise(t, v, tb):
+        if v is None:
+            v = t()
+        if v.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+
+def joinPath(modname, relativePath):
+    """Adjust a module name by a '/'-separated, relative or absolute path."""
+
+    module = modname.split('.')
+    for p in relativePath.split('/'):
+
+        if p == '..':
+            module.pop()
+        elif not p:
+            module = []
+        elif p != '.':
+            module.append(p)
+
+    return '.'.join(module)
+
+
+def lazyModule(modname, relativePath=None):
+    """Return module 'modname', but with its contents loaded "on demand".
+
+    This function returns 'sys.modules[modname]', if present.  Otherwise
+    it creates a 'LazyModule' object for the specified module, caches it
+    in 'sys.modules', and returns it.
+
+    'LazyModule' is a subclass of the standard Python module type, that
+    remains empty until an attempt is made to access one of its
+    attributes.  At that moment, the module is loaded into memory, and
+    any hooks that were defined via 'whenImported()' are invoked.
+
+    Note that calling 'lazyModule' with the name of a non-existent or
+    unimportable module will delay the 'ImportError' until the moment
+    access is attempted.  The 'ImportError' will occur every time an
+    attribute access is attempted, until the problem is corrected.
+
+    This function also takes an optional second parameter, 'relativePath',
+    which will be interpreted as a '/'-separated path string relative to
+    'modname'.  If a 'relativePath' is supplied, the module found by
+    traversing the path will be loaded instead of 'modname'.  In the path,
+    '.' refers to the current module, and '..' to the current module's
+    parent.  For example::
+
+        fooBaz = lazyModule('foo.bar','../baz')
+
+    will return the module 'foo.baz'.  The main use of the 'relativePath'
+    feature is to allow relative imports in modules that are intended for
+    use with module inheritance.  Where an absolute import would be carried
+    over as-is into the inheriting module, an import relative to '__name__'
+    will be relative to the inheriting module, e.g.::
+
+        something = lazyModule(__name__,'../path/to/something')
+
+    The above code will have different results in each module that inherits
+    it.
+
+    (Note: 'relativePath' can also be an absolute path (starting with '/');
+    this is mainly useful for module '__bases__' lists.)
+
+    """
+
+    def _loadModule(module):
+        acquire_lock()  # This is the main change from the PEAK version. They didn't protect these first 8 lines.
+        oldGA = LazyModule.__getattribute__
+        oldSA = LazyModule.__setattr__
+
+        modGA = ModuleType.__getattribute__
+        modSA = ModuleType.__setattr__
+
+        LazyModule.__getattribute__ = modGA
+        LazyModule.__setattr__ = modSA
+
+        try:
+            try:
+                # don't reload if already loaded!
+                if module.__dict__.keys() == ['__name__']:
+                    # Get Python to do the real import!
+                    reload(module)
+                try:
+                    for hook in getModuleHooks(module.__name__):
+                        hook(module)
+                finally:
+                    # Ensure hooks are not called again, even if they fail
+                    postLoadHooks[module.__name__] = None
+            except:
+                # Reset our state so that we can retry later
+                if '__file__' not in module.__dict__:
+                    LazyModule.__getattribute__ = oldGA.im_func
+                    LazyModule.__setattr__ = oldSA.im_func
+                raise
+
+            try:
+                # Convert to a real module (if under 2.2)
+                module.__class__ = ModuleType
+            except TypeError:
+                pass    # 2.3 will fail, but no big deal
+
+        finally:
+            release_lock()
+
+    class LazyModule(ModuleType):
+        __slots__ = ()
+
+        def __init__(self, name):
+            ModuleType.__setattr__(self, '__name__', name)
+            # super(LazyModule,self).__init__(name)
+
+        def __getattribute__(self, attr):
+            _loadModule(self)
+            return ModuleType.__getattribute__(self, attr)
+
+        def __setattr__(self, attr, value):
+            _loadModule(self)
+            return ModuleType.__setattr__(self, attr, value)
+
+    if relativePath:
+        modname = joinPath(modname, relativePath)
+
+    acquire_lock()
+    try:
+        if modname not in modules:
+            getModuleHooks(modname)  # force an empty hook list into existence
+            modules[modname] = LazyModule(modname)
+            if '.' in modname:
+                # ensure parent module/package is in sys.modules
+                # and parent.modname=module, as soon as the parent is imported
+                splitpos = modname.rindex('.')
+                whenImported(
+                    modname[:splitpos],
+                    lambda m: setattr(m, modname[splitpos+1:], modules[modname])
+                )
+        return modules[modname]
+    finally:
+        release_lock()
+
+
+postLoadHooks = {}
+
+
+def getModuleHooks(moduleName):
+    """Get list of hooks for 'moduleName'; error if module already loaded."""
+
+    acquire_lock()
+    try:
+        hooks = postLoadHooks.setdefault(moduleName, [])
+        if hooks is None:
+            raise AlreadyRead("Module already imported", moduleName)
+        return hooks
+    finally:
+        release_lock()
+
+
+def _setModuleHook(moduleName, hook):
+    acquire_lock()
+    try:
+        if moduleName in modules and postLoadHooks.get(moduleName) is None:
+            # Module is already imported/loaded, just call the hook
+            module = modules[moduleName]
+            hook(module)
+            return module
+
+        getModuleHooks(moduleName).append(hook)
+        return lazyModule(moduleName)
+    finally:
+        release_lock()
+
+
+def whenImported(moduleName, hook=None):
+    """Call 'hook(module)' when module named 'moduleName' is first used.
+
+    'hook' must accept one argument: the module object named by 'moduleName',
+    which must be a fully qualified (i.e. absolute) module name.  The hook
+    should not raise any exceptions, or it may prevent later hooks from
+    running.
+
+    If the module has already been imported normally, 'hook(module)' is
+    called immediately, and the module object is returned from this function.
+    If the module has not been imported, or has only been imported lazily,
+    then the hook is called when the module is first used, and a lazy import
+    of the module is returned from this function.  If the module was imported
+    lazily and used before calling this function, the hook is called
+    immediately, and the loaded module is returned from this function.
+
+    Note that using this function implies a possible lazy import of the
+    specified module, and lazy importing means that any 'ImportError' will be
+    deferred until the module is used.
+
+    """
+    if hook is None:
+        def decorate(func):
+            whenImported(moduleName, func)
+            return func
+        return decorate
+
+    if '.' in moduleName:
+        # If parent is not yet imported, delay hook installation until the
+        # parent is imported.
+        splitpos = moduleName.rindex('.')
+        whenImported(
+            moduleName[:splitpos], lambda m: _setModuleHook(moduleName, hook)
+        )
+    else:
+        return _setModuleHook(moduleName, hook)

--- a/zazu/imports.py
+++ b/zazu/imports.py
@@ -1,0 +1,188 @@
+"""Tools for doing dynamic imports Modified from https://github.com/PEAK-Legacy/Importing."""
+
+__all__ = [
+    'lazyModule', 'whenImported', 'getModuleHooks',
+]
+
+from types import ModuleType
+try:
+    from types import StringTypes
+except ImportError:
+    StringTypes = str
+from sys import modules
+from imp import acquire_lock, release_lock
+
+
+class AlreadyRead(Exception):
+    pass
+
+
+try:
+    exec("def reraise(t, v, tb): raise t, v, tb")
+except SyntaxError:
+    def reraise(t, v, tb):
+        if v is None:
+            v = t()
+        if v.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+
+def lazyModule(modname):
+    """Return module 'modname', but with its contents loaded "on demand".
+
+    This function returns 'sys.modules[modname]', if present.  Otherwise
+    it creates a 'LazyModule' object for the specified module, caches it
+    in 'sys.modules', and returns it.
+
+    'LazyModule' is a subclass of the standard Python module type, that
+    remains empty until an attempt is made to access one of its
+    attributes.  At that moment, the module is loaded into memory, and
+    any hooks that were defined via 'whenImported()' are invoked.
+
+    Note that calling 'lazyModule' with the name of a non-existent or
+    unimportable module will delay the 'ImportError' until the moment
+    access is attempted.  The 'ImportError' will occur every time an
+    attribute access is attempted, until the problem is corrected.
+
+    """
+
+    def _loadModule(module):
+        acquire_lock()  # This is the main change from the PEAK version. They didn't protect these first 8 lines.
+        oldGA = LazyModule.__getattribute__
+        oldSA = LazyModule.__setattr__
+
+        modGA = ModuleType.__getattribute__
+        modSA = ModuleType.__setattr__
+
+        LazyModule.__getattribute__ = modGA
+        LazyModule.__setattr__ = modSA
+
+        try:
+            try:
+                # don't reload if already loaded!
+                if module.__dict__.keys() == ['__name__']:
+                    # Get Python to do the real import!
+                    reload(module)
+                try:
+                    for hook in getModuleHooks(module.__name__):
+                        hook(module)
+                finally:
+                    # Ensure hooks are not called again, even if they fail
+                    postLoadHooks[module.__name__] = None
+            except:
+                # Reset our state so that we can retry later
+                if '__file__' not in module.__dict__:
+                    LazyModule.__getattribute__ = oldGA.im_func
+                    LazyModule.__setattr__ = oldSA.im_func
+                raise
+
+            try:
+                # Convert to a real module (if under 2.2)
+                module.__class__ = ModuleType
+            except TypeError:
+                pass    # 2.3 will fail, but no big deal
+
+        finally:
+            release_lock()
+
+    class LazyModule(ModuleType):
+        __slots__ = ()
+
+        def __init__(self, name):
+            ModuleType.__setattr__(self, '__name__', name)
+            # super(LazyModule,self).__init__(name)
+
+        def __getattribute__(self, attr):
+            _loadModule(self)
+            return ModuleType.__getattribute__(self, attr)
+
+        def __setattr__(self, attr, value):
+            _loadModule(self)
+            return ModuleType.__setattr__(self, attr, value)
+
+    acquire_lock()
+    try:
+        if modname not in modules:
+            getModuleHooks(modname)  # force an empty hook list into existence
+            modules[modname] = LazyModule(modname)
+            if '.' in modname:
+                # ensure parent module/package is in sys.modules
+                # and parent.modname=module, as soon as the parent is imported
+                splitpos = modname.rindex('.')
+                whenImported(
+                    modname[:splitpos],
+                    lambda m: setattr(m, modname[splitpos+1:], modules[modname])
+                )
+        return modules[modname]
+    finally:
+        release_lock()
+
+
+postLoadHooks = {}
+
+
+def getModuleHooks(moduleName):
+    """Get list of hooks for 'moduleName'; error if module already loaded."""
+
+    acquire_lock()
+    try:
+        hooks = postLoadHooks.setdefault(moduleName, [])
+        if hooks is None:
+            raise AlreadyRead("Module already imported", moduleName)
+        return hooks
+    finally:
+        release_lock()
+
+
+def _setModuleHook(moduleName, hook):
+    acquire_lock()
+    try:
+        if moduleName in modules and postLoadHooks.get(moduleName) is None:
+            # Module is already imported/loaded, just call the hook
+            module = modules[moduleName]
+            hook(module)
+            return module
+
+        getModuleHooks(moduleName).append(hook)
+        return lazyModule(moduleName)
+    finally:
+        release_lock()
+
+
+def whenImported(moduleName, hook=None):
+    """Call 'hook(module)' when module named 'moduleName' is first used.
+
+    'hook' must accept one argument: the module object named by 'moduleName',
+    which must be a fully qualified (i.e. absolute) module name.  The hook
+    should not raise any exceptions, or it may prevent later hooks from
+    running.
+
+    If the module has already been imported normally, 'hook(module)' is
+    called immediately, and the module object is returned from this function.
+    If the module has not been imported, or has only been imported lazily,
+    then the hook is called when the module is first used, and a lazy import
+    of the module is returned from this function.  If the module was imported
+    lazily and used before calling this function, the hook is called
+    immediately, and the loaded module is returned from this function.
+
+    Note that using this function implies a possible lazy import of the
+    specified module, and lazy importing means that any 'ImportError' will be
+    deferred until the module is used.
+
+    """
+    if hook is None:
+        def decorate(func):
+            whenImported(moduleName, func)
+            return func
+        return decorate
+
+    if '.' in moduleName:
+        # If parent is not yet imported, delay hook installation until the
+        # parent is imported.
+        splitpos = moduleName.rindex('.')
+        whenImported(
+            moduleName[:splitpos], lambda m: _setModuleHook(moduleName, hook)
+        )
+    else:
+        return _setModuleHook(moduleName, hook)

--- a/zazu/plugins/github_code_reviewer.py
+++ b/zazu/plugins/github_code_reviewer.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """Enables code review using github."""
-import zazu.code_reviewer
-import zazu.plugins.github_issue_tracker
 import zazu.util
 zazu.util.lazy_import(locals(), [
     'git',
     'github',
-    'os'
+    'os',
+    'zazu.code_reviewer'
+    'zazu.plugins.github_issue_tracker'
 ])
 
 __author__ = 'Nicholas Wiles'

--- a/zazu/plugins/github_issue_tracker.py
+++ b/zazu/plugins/github_issue_tracker.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Clasess that adapt GitHub for use as a zazu IssueTracker."""
-import zazu.github_helper
-import zazu.issue_tracker
+"""Classes that adapt GitHub for use as a zazu IssueTracker."""
 import zazu.util
 zazu.util.lazy_import(locals(), [
     'git',
     'github',
-    'os'
+    'os',
+    'zazu.github_helper',
+    'zazu.issue_tracker',
 ])
 
 __author__ = 'Nicholas Wiles'

--- a/zazu/plugins/github_scm_host.py
+++ b/zazu/plugins/github_scm_host.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """Clasess that adapt GitHub for use as a zazu ScmHost."""
-import zazu.github_helper
-import zazu.scm_host
 import zazu.util
 zazu.util.lazy_import(locals(), [
     'github',
-    'os'
+    'os',
+    'zazu.github_helper',
+    'zazu.scm_host',
 ])
 
 __author__ = 'Nicholas Wiles'

--- a/zazu/plugins/jira_issue_tracker.py
+++ b/zazu/plugins/jira_issue_tracker.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Clasess that adapt JIRA for use as a zazu IssueTracker."""
-import zazu.credential_helper
-import zazu.issue_tracker
+"""Classes that adapt JIRA for use as a zazu IssueTracker."""
 import zazu.util
 zazu.util.lazy_import(locals(), [
     'click',
     'jira',
-    're'
+    're',
+    'zazu.credential_helper',
+    'zazu.issue_tracker',
 ])
 
 __author__ = 'Nicholas Wiles'

--- a/zazu/repo/commands.py
+++ b/zazu/repo/commands.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 """Holds the zazu repo subcommand."""
-import zazu.config
-import zazu.git_helper
-import zazu.github_helper
 import zazu.util
 zazu.util.lazy_import(locals(), [
     'click',
@@ -10,7 +7,10 @@ zazu.util.lazy_import(locals(), [
     'git',
     'os',
     'semantic_version',
-    'socket'
+    'socket',
+    'zazu.config',
+    'zazu.git_helper',
+    'zazu.github_helper',
 ])
 
 __author__ = 'Nicholas Wiles'

--- a/zazu/style.py
+++ b/zazu/style.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 """Style functions for zazu."""
-import zazu.config
-import zazu.git_helper
-import zazu.styler
 import zazu.util
 zazu.util.lazy_import(locals(), [
     'click',
@@ -10,7 +7,10 @@ zazu.util.lazy_import(locals(), [
     'functools',
     'os',
     'threading',
-    'sys'
+    'sys',
+    'zazu.config',
+    'zazu.git_helper',
+    'zazu.styler',
 ])
 
 __author__ = 'Nicholas Wiles'

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -29,6 +29,8 @@ def lazy_import(scope, imports):
             d = import_mock
             while len(modules) > 1:
                 d = {modules.pop(): d}
+            if modules[0] in scope:
+                continue
             scope[modules[0]] = LazyImport(**d)
         else:
             scope[modules[0]] = import_mock

--- a/zazu/util.py
+++ b/zazu/util.py
@@ -20,11 +20,11 @@ def lazy_import(scope, imports):
 
         def __init__(self, **entries):
             self.__dict__.update(entries)
-    import peak.util.imports
-    assert peak.util.imports
+    import zazu.imports
+    assert zazu.imports
     for i in imports:
         modules = i.split('.')
-        import_mock = peak.util.imports.lazyModule(i)
+        import_mock = zazu.imports.lazyModule(i)
         if len(modules) > 1:
             d = import_mock
             while len(modules) > 1:


### PR DESCRIPTION
- Delay loading dynamic plugins unless they are needed. (Saves ~0.3s)
- Lazy import zazu modules.
- Upgrade to latest keyring (Saves ~0.3s)
- Add [fastentrypoints](https://pypi.org/project/fastentrypoints/) patch to setup.py to make non bdist-wheel install entry points faster.

Fixes #158