### PR TITLE
Handle failure if branch not pushed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,5 @@ ENV/
 .ropeproject
 version.txt
 
-# vscode project settings
+# Visual Studio Code project settings
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ENV/
 # Rope project settings
 .ropeproject
 version.txt
+
+# vscode project settings
+.vscode/

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import click
 import click.testing
-import git
 import tests.conftest as conftest
 import pytest
 import webbrowser

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -277,8 +277,10 @@ def test_review_dirty_working_tree(mocker, git_repo_with_local_origin, tmp_dir):
     mocked_reviewer = mocker.Mock()
     mocked_reviewer.review = mocker.Mock(return_value=[])
     mocked_reviewer.create_review = mocker.Mock()
-    with open('un-tracked_file.txt', 'w') as f: pass
-    with zazu.util.cd(git_repo_with_local_origin.working_tree_dir):
+    mocker.patch('zazu.config.Config.code_reviewer', return_value=mocked_reviewer)
+    with zazu.util.cd(tmp_dir):
+        with open('un-tracked_file.txt', 'w'):
+            pass
         runner = click.testing.CliRunner()
         result = runner.invoke(zazu.cli.cli, ['dev', 'review'])
         assert not mocked_reviewer.called

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -270,6 +270,7 @@ def test_review_push_fails(mocker, git_repo):
     with zazu.util.cd(git_repo.working_tree_dir):
         runner = click.testing.CliRunner()
         result = runner.invoke(zazu.cli.cli, ['dev', 'review'])
+        assert not mocked_reviewer.called
         assert result.exception
         assert result.exit_code == 1
 
@@ -286,7 +287,6 @@ def test_review_dirty_working_tree(mocker, git_repo_with_local_origin, tmp_dir):
     mocker.patch('zazu.util.prompt', side_effect=['title', 'summary'])
     pathlib.Path(tmp_dir).joinpath('un-tracked_file.txt').touch()
     with zazu.util.cd(git_repo_with_local_origin.working_tree_dir):
-        git_repo_with_local_origin
         runner = click.testing.CliRunner()
         result = runner.invoke(zazu.cli.cli, ['dev', 'review'])
         assert result.exception

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -267,7 +267,7 @@ def test_review_push_fails(mocker, git_repo):
     with zazu.util.cd(git_repo.working_tree_dir):
         runner = click.testing.CliRunner()
         result = runner.invoke(zazu.cli.cli, ['dev', 'review'])
-        assert not mocked_reviewer.called
+        mocked_reviewer.create_review.assert_not_called()
         assert result.exception
         assert result.exit_code == 1
 
@@ -282,7 +282,7 @@ def test_review_dirty_working_tree(mocker, git_repo_with_local_origin, tmp_dir):
             pass
         runner = click.testing.CliRunner()
         result = runner.invoke(zazu.cli.cli, ['dev', 'review'])
-        assert not mocked_reviewer.called
+        mocked_reviewer.create_review.assert_not_called()
         assert result.exception
         assert result.exit_code == 1
 

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -87,6 +87,7 @@ def test_make_ticket(mocker):
                                                             description='description',
                                                             component='component')
 
+
 def test_check_if_branch_is_protected():
     protected_branches = ['develop', 'master']
     for b in protected_branches:

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -262,13 +262,9 @@ def test_review(mocker, git_repo_with_local_origin):
 
 
 def test_review_push_fails(mocker, git_repo):
-    mocker.patch('webbrowser.open_new')
-    mocked_tracker = mocker.Mock()
-    mocked_tracker.issue = mocker.Mock(side_effect=zazu.issue_tracker.IssueTrackerError)
     mocked_reviewer = mocker.Mock()
     mocked_reviewer.review = mocker.Mock(return_value=[])
     mocked_reviewer.create_review = mocker.Mock()
-    mocker.patch('zazu.config.Config.issue_tracker', return_value=mocked_tracker)
     mocker.patch('zazu.config.Config.code_reviewer', return_value=mocked_reviewer)
     mocker.patch('zazu.util.prompt', side_effect=['title', 'summary'])
     with zazu.util.cd(git_repo.working_tree_dir):

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -242,7 +242,7 @@ def test_ticket_from_active_branch(mocker, git_repo):
         webbrowser.open_new.assert_called_once_with('url')
 
 
-def test_review(mocker, git_repo):
+def test_review(mocker, git_repo_with_local_origin):
     mocker.patch('webbrowser.open_new')
     mocked_tracker = mocker.Mock()
     mocked_tracker.issue = mocker.Mock(side_effect=zazu.issue_tracker.IssueTrackerError)
@@ -252,7 +252,7 @@ def test_review(mocker, git_repo):
     mocker.patch('zazu.config.Config.issue_tracker', return_value=mocked_tracker)
     mocker.patch('zazu.config.Config.code_reviewer', return_value=mocked_reviewer)
     mocker.patch('zazu.util.prompt', side_effect=['title', 'summary'])
-    with zazu.util.cd(git_repo.working_tree_dir):
+    with zazu.util.cd(git_repo_with_local_origin.working_tree_dir):
         runner = click.testing.CliRunner()
         result = runner.invoke(zazu.cli.cli, ['dev', 'review'])
         assert not result.exception

--- a/zazu/dev/commands.py
+++ b/zazu/dev/commands.py
@@ -313,6 +313,7 @@ def review(config, base, head):
         if dirty:
             raise click.ClickException('working tree is not clean, stash or remove changes before review')    
         try:
+            click.echo('Pushing to origin...')
             config.repo.git.push('--set-upstream','origin', head)
         except git.exc.GitCommandError as e:
             raise click.ClickException('failed to push to origin: {}'.format(str(e)))    

--- a/zazu/dev/commands.py
+++ b/zazu/dev/commands.py
@@ -315,7 +315,7 @@ def review(config, base, head):
         try:
             config.repo.git.push('--set-upstream','origin', head)
         except git.exc.GitCommandError as e:
-            raise click.ClickException('failed to push to origin: {}'.format(str(e))    
+            raise click.ClickException('failed to push to origin: {}'.format(str(e)))    
         issue_id = descriptor.id
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             issue_future = executor.submit(config.issue_tracker().issue, issue_id)

--- a/zazu/dev/commands.py
+++ b/zazu/dev/commands.py
@@ -311,12 +311,12 @@ def review(config, base, head):
         descriptor = make_issue_descriptor(head)
         dirty = config.repo.git.status(['--porcelain'])
         if dirty:
-            raise click.ClickException('working tree is not clean, stash or remove changes before review')    
+            raise click.ClickException('working tree is not clean, stash or remove changes before review')
         try:
             click.echo('Pushing to origin...')
-            config.repo.git.push('--set-upstream','origin', head)
+            config.repo.git.push('--set-upstream', 'origin', head)
         except git.exc.GitCommandError as e:
-            raise click.ClickException('failed to push to origin: {}'.format(str(e)))    
+            raise click.ClickException('failed to push to origin: {}'.format(str(e)))
         issue_id = descriptor.id
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             issue_future = executor.submit(config.issue_tracker().issue, issue_id)

--- a/zazu/dev/commands.py
+++ b/zazu/dev/commands.py
@@ -309,13 +309,13 @@ def review(config, base, head):
         pr = zazu.util.pick(existing_reviews, 'Multiple reviews found, pick one')
     else:
         descriptor = make_issue_descriptor(head)
-        status = config.repo.git.status(['--porcelain'])
-        if status:
-            raise click.ClickException('working tree is not clean, stash or remove changes in your repo')    
+        dirty = config.repo.git.status(['--porcelain'])
+        if dirty:
+            raise click.ClickException('working tree is not clean, stash or remove changes before review')    
         try:
             config.repo.git.push('--set-upstream','origin', head)
         except git.exc.GitCommandError as e:
-            raise click.ClickException('failed to push to origin: {}'.format(e))    
+            raise click.ClickException('failed to push to origin: {}'.format(str(e))    
         issue_id = descriptor.id
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             issue_future = executor.submit(config.issue_tracker().issue, issue_id)

--- a/zazu/dev/commands.py
+++ b/zazu/dev/commands.py
@@ -309,6 +309,13 @@ def review(config, base, head):
         pr = zazu.util.pick(existing_reviews, 'Multiple reviews found, pick one')
     else:
         descriptor = make_issue_descriptor(head)
+        status = config.repo.git.status(['--porcelain'])
+        if status:
+            raise click.ClickException('working tree is not clean, stash or remove changes in your repo')    
+        try:
+            config.repo.git.push('--set-upstream','origin', head)
+        except git.exc.GitCommandError as e:
+            raise click.ClickException('failed to push to origin: {}'.format(e))    
         issue_id = descriptor.id
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             issue_future = executor.submit(config.issue_tracker().issue, issue_id)


### PR DESCRIPTION
zazu dev review should check for dirty working tree and push if the branch has not been pushed

Fixes #161